### PR TITLE
Fix GuavaOptionalSerializer.isEmpty()

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/GuavaOptionalSerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/GuavaOptionalSerializer.java
@@ -208,7 +208,7 @@ public final class GuavaOptionalSerializer
         JsonSerializer<Object> ser = _valueSerializer;
         if (ser == null) {
             try {
-                ser = _findCachedSerializer(provider, value.getClass());
+                ser = _findCachedSerializer(provider, contents.getClass());
             } catch (JsonMappingException e) { // nasty but necessary
                 throw new RuntimeJsonMappingException(e);
             }

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/optional/OptionalBasicTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/optional/OptionalBasicTest.java
@@ -166,6 +166,46 @@ public class OptionalBasicTest extends ModuleTestBase
         assertEquals("{\"myString\":\"simpleString\"}", value);
     }
 
+    public void testSerPropInclusionAlways() throws Exception {
+        OptionalGenericData<String> data = new OptionalGenericData<String>();
+        data.myData = Optional.of("simpleString");
+        // NOTE: pass 'true' to ensure "legacy" setting
+        String value = mapperWithModule(true)
+                .setPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS))
+                .writeValueAsString(data);
+        assertEquals("{\"myData\":\"simpleString\"}", value);
+    }
+
+    public void testSerPropInclusionNonNull() throws Exception {
+        OptionalGenericData<String> data = new OptionalGenericData<String>();
+        data.myData = Optional.of("simpleString");
+        // NOTE: pass 'true' to ensure "legacy" setting
+        String value = mapperWithModule(true)
+                .setPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_NULL))
+                .writeValueAsString(data);
+        assertEquals("{\"myData\":\"simpleString\"}", value);
+    }
+
+    public void testSerPropInclusionNonAbsent() throws Exception {
+        OptionalGenericData<String> data = new OptionalGenericData<String>();
+        data.myData = Optional.of("simpleString");
+        // NOTE: pass 'true' to ensure "legacy" setting
+        String value = mapperWithModule(true)
+                .setPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_ABSENT))
+                .writeValueAsString(data);
+        assertEquals("{\"myData\":\"simpleString\"}", value);
+    }
+
+    public void testSerPropInclusionNonEmpty() throws Exception {
+        OptionalGenericData<String> data = new OptionalGenericData<String>();
+        data.myData = Optional.of("simpleString");
+        // NOTE: pass 'true' to ensure "legacy" setting
+        String value = mapperWithModule(true)
+                .setPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_EMPTY))
+                .writeValueAsString(data);
+        assertEquals("{\"myData\":\"simpleString\"}", value);
+    }
+
     public void testSerGeneric() throws Exception {
         OptionalGenericData<String> data = new OptionalGenericData<String>();
         data.myData = Optional.of("simpleString");


### PR DESCRIPTION
Previous code was incorrectly grabbing the class of Optional<T> not the class of T.

I wasn't sure if there was an easier way to get the tests to fire. I had a little trouble getting it to fire at all as I hadn't realized there were two different types of property inclusion (value and content).