### PR TITLE
Guava Optional does not propagate TypeInfo.

### DIFF
--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/optional/TestOptionalWithPolymorphic.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/optional/TestOptionalWithPolymorphic.java
@@ -56,6 +56,11 @@ public class TestOptionalWithPolymorphic extends ModuleTestBase
         public Optional<java.io.Serializable> value;
     }
 
+    static class TypeInfoOptional {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "$type")
+        public Optional<Strategy> value;
+    }
+
     /*
     /**********************************************************************
     /* Test methods
@@ -108,6 +113,13 @@ public class TestOptionalWithPolymorphic extends ModuleTestBase
         Object ob = result.value.get();
         assertEquals(Integer.class, ob.getClass());
         assertEquals(Integer.valueOf(5), ob);
+    }
+
+    public void testOptionalPropagatesTypeInfo() throws Exception
+    {
+        TypeInfoOptional data = new TypeInfoOptional();
+        data.value = Optional.<Strategy>of(new Foo(42));
+        assertEquals(aposToQuotes("{'value':{'$type':'Foo','foo':42}}"), MAPPER.writeValueAsString(data));
     }
 
     private void _test(ObjectMapper m, Map<String, ?> map) throws Exception


### PR DESCRIPTION
The only functionality I haven't been able to restore in migrating Scala's Option to the new ReferenceType paradigm is propagating an `@JsonTypeInfo` annotation to the content type. The same issue currently exists with Guava's Optional and I can assume it exists with JDK Optional and AtomicReferences too.

The error with the test is this:
```
Expected :{"value":{"$type":"Foo","foo":42}}
Actual   :{"value":["Present",{"type":"Foo","foo":42}]}
```

If you replace the `Optional<Strategy>` with `Strategy` the test passes.

It's worth noting that `findCollectionLikeSerializer` can find the proper `TypeSerializer` via `type.getContentType().getTypeHandler()`. However `findReferenceType`'s referencedType has not already discovered this type handler.

I'm still in the middle of tracking down where/how databind ends up doing something different between ReferenceType and CollectionLikeType. So far I've tracked the earliest difference (it differs earlier yet, though, I unfortunately have to take a break) to BeanSerializerBase.java:281 (First line of the for loop in resolve(SerializerProvider provider). The _props[i] for only the `CollectionLikeType` returns a "hard coded" version of JavaType (via `getSerializationType()`) that contains an `_elementType._TypeHandler`, whereas the `ReferenceType` variant does not have a "hard coded" serialization type.