### PR TITLE
Issue 6, MultiMap deserializer fix

### DIFF
--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultimaps.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultimaps.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.datatype.guava;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.pojo.AddOp;
 import com.fasterxml.jackson.datatype.guava.pojo.MathOp;
@@ -308,5 +309,45 @@ public class TestMultimaps extends ModuleTestBase
 
         ImmutableMultimapWrapper output = MAPPER.readValue(json, ImmutableMultimapWrapper.class);
         assertEquals(input, output);        
+    }
+    
+    public void testFromSingleValue() throws Exception
+    {
+        ObjectMapper mapper = mapperWithModule()
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":\"value\"}}",
+               new TypeReference<SampleMultiMapTest>() { });
+        
+        assertEquals(1, sampleTest.map.get("test").size());
+    }
+    
+    public void testFromMultiValueWithSingleValueOptionEnabled() throws Exception
+    {
+        ObjectMapper mapper = mapperWithModule()
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        
+        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":\"val\",\"test1\":[\"val1\",\"val2\"]}}",
+                new TypeReference<SampleMultiMapTest>() { });
+        
+        assertEquals(1, sampleTest.map.get("test").size());
+        assertEquals(2, sampleTest.map.get("test1").size());
+        
+    }
+    
+    public void testFromMultiValueWithNoSingleValueOptionEnabled() throws Exception
+    {
+        ObjectMapper mapper = mapperWithModule();
+        
+        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":[\"val\"],\"test1\":[\"val1\",\"val2\"]}}",
+                new TypeReference<SampleMultiMapTest>() { });
+        
+        assertEquals(1, sampleTest.map.get("test").size());
+        assertEquals(2, sampleTest.map.get("test1").size());
+        
+    }
+    
+    //Sample class for testing multimaps single value option
+    static class SampleMultiMapTest {
+        public HashMultimap<String, String> map;
     }
 }

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultisets.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultisets.java
@@ -1,5 +1,8 @@
 package com.fasterxml.jackson.datatype.guava;
 
+import java.util.List;
+import java.util.Set;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.fasterxml.jackson.databind.*;
@@ -121,5 +124,45 @@ public class TestMultisets extends ModuleTestBase
                 new TypeReference<Multiset<String>>() { });
         assertEquals(1, set.size());
         assertTrue(set.contains("abc"));
+    }
+    
+    public void testFromSingleValue() throws Exception
+    {
+        ObjectMapper mapper = mapperWithModule()
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":\"value\"}}",
+               new TypeReference<SampleMultiMapTest>() { });
+       	
+       	assertEquals(1, sampleTest.map.get("test").size());
+    }
+    
+    public void testFromMultiValueWithSingleValueOptionEnabled() throws Exception
+    {
+        ObjectMapper mapper = mapperWithModule()
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+       	
+        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":\"val\",\"test1\":[\"val1\",\"val2\"]}}",
+                new TypeReference<SampleMultiMapTest>() { });
+       	
+       	assertEquals(1, sampleTest.map.get("test").size());
+       	assertEquals(2, sampleTest.map.get("test1").size());
+       	
+    }
+    
+    public void testFromMultiValueWithNoSingleValueOptionEnabled() throws Exception
+    {
+        ObjectMapper mapper = mapperWithModule();
+       	
+        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":[\"val\"],\"test1\":[\"val1\",\"val2\"]}}",
+                new TypeReference<SampleMultiMapTest>() { });
+       	
+       	assertEquals(1, sampleTest.map.get("test").size());
+       	assertEquals(2, sampleTest.map.get("test1").size());
+       	
+    }
+    
+    //Sample class for testing multimaps single value option
+    static class SampleMultiMapTest {
+        public HashMultimap<String, String> map;
     }
 }

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultisets.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultisets.java
@@ -1,8 +1,5 @@
 package com.fasterxml.jackson.datatype.guava;
 
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.fasterxml.jackson.databind.*;
@@ -124,45 +121,5 @@ public class TestMultisets extends ModuleTestBase
                 new TypeReference<Multiset<String>>() { });
         assertEquals(1, set.size());
         assertTrue(set.contains("abc"));
-    }
-    
-    public void testFromSingleValue() throws Exception
-    {
-        ObjectMapper mapper = mapperWithModule()
-            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
-        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":\"value\"}}",
-               new TypeReference<SampleMultiMapTest>() { });
-       	
-       	assertEquals(1, sampleTest.map.get("test").size());
-    }
-    
-    public void testFromMultiValueWithSingleValueOptionEnabled() throws Exception
-    {
-        ObjectMapper mapper = mapperWithModule()
-            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
-       	
-        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":\"val\",\"test1\":[\"val1\",\"val2\"]}}",
-                new TypeReference<SampleMultiMapTest>() { });
-       	
-       	assertEquals(1, sampleTest.map.get("test").size());
-       	assertEquals(2, sampleTest.map.get("test1").size());
-       	
-    }
-    
-    public void testFromMultiValueWithNoSingleValueOptionEnabled() throws Exception
-    {
-        ObjectMapper mapper = mapperWithModule();
-       	
-        SampleMultiMapTest sampleTest = mapper.readValue("{\"map\":{\"test\":[\"val\"],\"test1\":[\"val1\",\"val2\"]}}",
-                new TypeReference<SampleMultiMapTest>() { });
-       	
-       	assertEquals(1, sampleTest.map.get("test").size());
-       	assertEquals(2, sampleTest.map.get("test1").size());
-       	
-    }
-    
-    //Sample class for testing multimaps single value option
-    static class SampleMultiMapTest {
-        public HashMultimap<String, String> map;
     }
 }


### PR DESCRIPTION
Fix for #6 Multimap deserializer does not honor DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY.

If the option DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY is enabled, then if there is a single value, then I create a singleton list and add the value to it.
For the same option, I am allowing multiple array values also.

Let me know if this is fine.