### PR TITLE
Multimap deser Issue #6 behavior

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/multimap/GuavaMultimapDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/multimap/GuavaMultimapDeserializer.java
@@ -214,8 +214,8 @@ public abstract class GuavaMultimapDeserializer<T extends Multimap<Object,
             else {
                 // get the current token value
                 final Object value = getCurrentTokenValue(jp, ctxt);
-                // add the single value as a list
-                multimap.put(key, Collections.singletonList(value));
+                // add the single value
+                multimap.put(key, value);
             }
         }
         if (creatorMethod == null) {

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultimaps.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultimaps.java
@@ -331,7 +331,10 @@ public class TestMultimaps extends ModuleTestBase
         
         assertEquals(1, sampleTest.map.get("test").size());
         assertEquals(2, sampleTest.map.get("test1").size());
-        
+
+        // Make sure that our Value is still a String not [String]
+        assertEquals(sampleTest.map.entries().iterator().next().getValue(), "val");
+
     }
     
     public void testFromMultiValueWithNoSingleValueOptionEnabled() throws Exception


### PR DESCRIPTION
I don't believe that the behavior for DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY was working as expected.

If you do have a single value it is returning a Multimap\<Key, [Value]> instead of Multimap\<Key, Value>.

The [original tests](https://github.com/CookieAroundTheBend/jackson-datatypes-collections/blob/527cb0d3342d4abc9604584dc0061e3497dec0c6/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultimaps.java#L333) passing because they were just checking the size, not the types.

The added test is just making sure that the types are still what we would expect.
` // Make sure that our Value is still a String not [String]
        assertEquals(sampleTest.map.entries().iterator().next().getValue(), "val");`
