### PR TITLE
Widen OSGi import range to include Guava 22

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -25,7 +25,7 @@ Guava (http://code.google.com/p/guava-libraries/) types (currently mostly just c
     <version.guava>18.0</version.guava>
 
     <!-- 11-Sep-2015, tatu: As per [datatype-guava#80] -->
-    <version.guava.osgi>[${version.guava}.0,20)</version.guava.osgi>
+    <version.guava.osgi>[${version.guava}.0,22)</version.guava.osgi>
 
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/datatype/guava</packageVersion.dir>


### PR DESCRIPTION
My brief tests suggest that Guava 22 is compatible with the current functionality of the Guava module.