### PR TITLE
add support for java serialization to guava module

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -19,12 +19,16 @@ import com.fasterxml.jackson.datatype.guava.deser.multimap.list.LinkedListMultim
 import com.fasterxml.jackson.datatype.guava.deser.multimap.set.HashMultimapDeserializer;
 import com.fasterxml.jackson.datatype.guava.deser.multimap.set.LinkedHashMultimapDeserializer;
 
+import java.io.Serializable;
+
 /**
  * Custom deserializers module offers.
  */
 public class GuavaDeserializers
     extends Deserializers.Base
+    implements Serializable
 {
+    static final long serialVersionUID = 1L;
     protected BoundType _defaultBoundType;
 
     public GuavaDeserializers() {

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.guava;
 
+import java.io.Serializable;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -28,7 +29,10 @@ import com.fasterxml.jackson.datatype.guava.ser.RangeSerializer;
 import com.fasterxml.jackson.datatype.guava.ser.TableSerializer;
 
 public class GuavaSerializers extends Serializers.Base
+    implements Serializable
 {
+    static final long serialVersionUID = 1L;
+
     static class FluentConverter extends StdConverter<Object,Iterable<?>> {
         static final FluentConverter instance = new FluentConverter();
 

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaTypeModifier.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaTypeModifier.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.guava;
 
+import java.io.Serializable;
 import java.lang.reflect.Type;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -25,7 +26,10 @@ import com.google.common.collect.*;
  *</ul>
  */
 public class GuavaTypeModifier extends TypeModifier
+    implements Serializable
 {
+    static final long serialVersionUID = 1L;
+
     @Override
     public JavaType modifyType(JavaType type, Type jdkType, TypeBindings bindings, TypeFactory typeFactory)
     {

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/GuavaBeanSerializerModifier.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/GuavaBeanSerializerModifier.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.google.common.base.Optional;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -13,7 +14,9 @@ import java.util.List;
  * optional values iff handling of "absent as nulls" is enabled.
  */
 public class GuavaBeanSerializerModifier extends BeanSerializerModifier
+    implements Serializable
 {
+    static final long serialVersionUID = 1L;
     @Override
     public List<BeanPropertyWriter> changeProperties(SerializationConfig config,
             BeanDescription beanDesc,

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/JavaSerializableTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/JavaSerializableTest.java
@@ -1,0 +1,62 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class JavaSerializableTest extends ModuleTestBase {
+
+    public void testSerializable() throws IOException, ClassNotFoundException {
+        ObjectMapper mapper = mapperWithModule();
+
+        //validate we can still use it to deserialize jackson objects
+        ObjectMapper deserializedMapper = serializeAndDeserialize(mapper);
+        ImmutableSet<String> set = deserializedMapper.readValue("[\"abc\"]",
+                new TypeReference<ImmutableSet<String>>() { });
+        assertEquals(1, set.size());
+        assertTrue(set.contains("abc"));
+    }
+
+    public void testSerializableConfigureAbsentsAsNull() throws IOException, ClassNotFoundException {
+        ObjectMapper mapper = mapperWithModule(true);
+
+        //validate we can still use it to deserialize jackson objects
+        ObjectMapper deserializedMapper = serializeAndDeserialize(mapper);
+        ImmutableSet<String> set = deserializedMapper.readValue("[\"abc\"]",
+                new TypeReference<ImmutableSet<String>>() { });
+        assertEquals(1, set.size());
+        assertTrue(set.contains("abc"));
+
+        Optional<?> value = mapper.readValue("\"simpleString\"", new TypeReference<Optional<String>>() {});
+        assertTrue(value.isPresent());
+        assertEquals("simpleString", value.get());
+    }
+
+    private ObjectMapper serializeAndDeserialize(ObjectMapper mapper) throws IOException, ClassNotFoundException {
+        //verify serialization
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream);
+
+        outputStream.writeObject(mapper);
+        byte[] serializedBytes = byteArrayOutputStream.toByteArray();
+
+        //verify deserialization
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serializedBytes);
+        ObjectInputStream inputStream = new ObjectInputStream(byteArrayInputStream);
+
+        Object deserializedObject = inputStream.readObject();
+
+        //validate the object
+        assertTrue("Deserialized object should be an instance of ObjectMapper",
+                ObjectMapper.class == deserializedObject.getClass());
+
+        return (ObjectMapper) deserializedObject;
+    }
+}


### PR DESCRIPTION
Fixes #15 .  I based the set of classes to make serializable on GuavaModule.setupModule().  Let me know if there is anything I missed.  Can also move the Optional test as a seperate test under the optional subpackage if that is preferred.  