### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/guava/README.md
+++ b/guava/README.md
@@ -5,7 +5,7 @@ to support JSON serialization and deserialization of
 ## Status
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.datatype/jackson-datatype-guava/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.datatype/jackson-datatype-guava/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.datatype/jackson-datatype-guava/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-guava)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.datatype/jackson-datatype-guava.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-guava)
 
 Module has been production-ready since version 2.3.
 Not all datatypes of Guava are support due to sheer size of the library; new support is added based on contributions.

--- a/hppc/README.md
+++ b/hppc/README.md
@@ -7,7 +7,7 @@ Licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.t
 ## Status
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.datatype/jackson-datatype-hppc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.datatype/jackson-datatype-hppc/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.datatype/jackson-datatype-hppc/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-hppc)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.datatype/jackson-datatype-hppc.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-hppc)
 
 Currently (2.7) following things are supported:
 

--- a/pcollections/README.md
+++ b/pcollections/README.md
@@ -7,7 +7,7 @@ Licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.t
 ## Status
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.fasterxml.jackson.datatype/jackson-datatype-pcollections.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.datatype/jackson-datatype-pcollections/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.datatype/jackson-datatype-pcollections/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-pcollections)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.datatype/jackson-datatype-pcollections.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-pcollections)
 
 ## Usage
 


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io