### PR TITLE
Properly find type serializers for primitive->object maps

### DIFF
--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/deser/map/RefValueHandler.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/deser/map/RefValueHandler.java
@@ -39,11 +39,10 @@ public class RefValueHandler implements ValueHandler<RefValueHandler> {
         } else {
             deser = _valueDeserializer;
         }
-        TypeDeserializer typeDeser;
-        if (_typeDeserializerForValue == null) {
-            typeDeser = null;
-        } else {
-            typeDeser = _typeDeserializerForValue.forProperty(property);
+        TypeDeserializer typeDeser = _typeDeserializerForValue == null ?
+                ctxt.getFactory().findTypeDeserializer(ctxt.getConfig(), _valueType) : _typeDeserializerForValue;
+        if (typeDeser != null) {
+            typeDeser = typeDeser.forProperty(property);
         }
         //noinspection ObjectEquality
         if (deser == this._valueDeserializer && typeDeser == this._typeDeserializerForValue) {

--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/ser/map/PrimitiveRefMapSerializer.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/ser/map/PrimitiveRefMapSerializer.java
@@ -51,8 +51,11 @@ public abstract class PrimitiveRefMapSerializer<T extends PrimitiveObjectMap<V>,
     @Override
     public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property)
             throws JsonMappingException {
-        TypeSerializer vts = this._valueTypeSerializer == null ? null : this._valueTypeSerializer.forProperty(property);
         JavaType containedType = _type.containedTypeOrUnknown(0);
+        TypeSerializer vts = this._valueTypeSerializer == null ?
+                prov.findTypeSerializer(containedType) :
+                this._valueTypeSerializer;
+        if (vts != null) { vts = vts.forProperty(property); }
         JsonSerializer<Object> vs = this._valueSerializer == null && containedType.useStaticType() ?
                 prov.findValueSerializer(containedType) :
                 this._valueSerializer;

--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.datatype.eclipsecollections;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -100,6 +102,7 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.UnsortedMapIterable;
+import org.eclipse.collections.api.map.primitive.IntObjectMap;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.primitive.BooleanSet;
@@ -148,6 +151,7 @@ import org.eclipse.collections.impl.factory.primitive.FloatLists;
 import org.eclipse.collections.impl.factory.primitive.FloatSets;
 import org.eclipse.collections.impl.factory.primitive.IntBags;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
+import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
 import org.eclipse.collections.impl.factory.primitive.IntSets;
 import org.eclipse.collections.impl.factory.primitive.LongBags;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
@@ -518,5 +522,39 @@ public final class DeserializerTest extends ModuleTestBase {
         if (type == double.class) { return ThreadLocalRandom.current().nextDouble(); }
         if (type == Object.class) { return randomSample(char.class).toString(); }
         throw new AssertionError();
+    }
+
+    @Test
+    public void typeInfoObjectMap() throws IOException {
+        Assert.assertEquals(
+                mapperWithModule()
+                        .readValue("{\"map\":{\"0\":{\"@c\":\".DeserializerTest$B\"}}}", Container.class).map,
+                IntObjectMaps.immutable.of(0, new B())
+        );
+    }
+
+    private static class Container {
+        public IntObjectMap<A> map;
+    }
+
+    @JsonSubTypes(@JsonSubTypes.Type(B.class))
+    @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
+    private static abstract class A {
+
+    }
+
+    private static class B extends A {
+        public B() {
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof B;
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
     }
 }

--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/SerializerTest.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/SerializerTest.java
@@ -11,6 +11,7 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.MutableMapIterable;
+import org.eclipse.collections.api.map.primitive.IntObjectMap;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
@@ -19,6 +20,7 @@ import org.eclipse.collections.impl.factory.primitive.CharLists;
 import org.eclipse.collections.impl.factory.primitive.DoubleLists;
 import org.eclipse.collections.impl.factory.primitive.FloatLists;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
+import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.factory.primitive.ShortLists;
 import org.junit.Assert;
@@ -135,5 +137,26 @@ public final class SerializerTest extends ModuleTestBase {
                 mapperWithModule().writerFor(new TypeReference<MapIterable<String, String>>() {})
                         .writeValueAsString(Maps.immutable.of("abc", "def"))
         );
+    }
+
+    @Test
+    public void typeInfoObjectMap() throws JsonProcessingException {
+        Assert.assertEquals(
+                "{\"map\":{\"0\":{\"@c\":\".SerializerTest$B\"}}}",
+                mapperWithModule().writeValueAsString(new Container())
+        );
+    }
+
+    private static class Container {
+        public final IntObjectMap<A> map = IntObjectMaps.immutable.of(0, new B());
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
+    private static abstract class A {
+
+    }
+
+    private static class B extends A {
+
     }
 }


### PR DESCRIPTION
The issue is that when types that need type serializers appear in a primitive->ref map the type info is not properly recognized.

All other serializers I could find solve this at the serializer creation site (i.e. findSerializer), but this is always in the specializations (findCollectionLikeSerializer, findMapLikeSerializer) which are unavailable for eclipse-collections due to reasons discussed in #29. This PR is the only alternative I could see for getting the type serializer for eclipse-collections, but I'd be happy with a better solution.