### PR TITLE
Increasing guava version limit

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -25,7 +25,7 @@ Guava (http://code.google.com/p/guava-libraries/) types (currently mostly just c
     <version.guava>20.0</version.guava>
 
     <!-- 11-Sep-2015, tatu: As per [datatype-guava#80] -->
-    <version.guava.osgi>[${version.guava}.0,22)</version.guava.osgi>
+    <version.guava.osgi>[${version.guava}.0,25)</version.guava.osgi>
 
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/datatype/guava</packageVersion.dir>


### PR DESCRIPTION
Hi, I ran all tests with guava versions 23 through 25 and they were all green 
(except for failing.OptionalUnwrappedTest, which is on purpose? didn't work with v20 either, so it would explain the package name...)

This led me to the conclusion that it's save to increase the guava version limit.

This is important, [because there is a security issue on versions 11.0 through 24.1](https://github.com/google/guava/wiki/CVE-2018-10237).

Thanks