### PR TITLE
Fix deserializer order for ref->ref maps

### DIFF
--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/deser/map/EclipseMapDeserializers.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/deser/map/EclipseMapDeserializers.java
@@ -278,8 +278,8 @@ public final class EclipseMapDeserializers {
                                MapIterable.class.isAssignableFrom(rawClass);
             boolean refKey = refValue ? (typeParameters.size() == 2) : (typeParameters.size() == 1);
 
-            K keyHandler = typeHandlerPair.keyHandler(refKey ? typeParameters.get(typeParameters.size() - 1) : null);
-            V valueHandler = typeHandlerPair.valueHandler(refValue ? typeParameters.get(0) : null);
+            K keyHandler = typeHandlerPair.keyHandler(refKey ? typeParameters.get(0) : null);
+            V valueHandler = typeHandlerPair.valueHandler(refValue ? typeParameters.get(typeParameters.size() - 1) : null);
 
             return new DeserializerImpl(keyHandler, valueHandler);
         }

--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
@@ -650,4 +650,14 @@ public final class DeserializerTest extends ModuleTestBase {
                 mapperWithModule().readValue(json, new TypeReference<ObjectIntPair<A>>() {})
         );
     }
+
+    @Test
+    public void nestedMap() throws Exception {
+        MutableMap<String, MutableMap<String, String>> pair = Maps.mutable.of("a", Maps.mutable.of("b", "c"));
+        String json = "{\"a\":{\"b\":\"c\"}}";
+        TypeReference<MutableMap<String, MutableMap<String, String>>> type =
+                new TypeReference<MutableMap<String, MutableMap<String, String>>>() {};
+        Assert.assertEquals(json, mapperWithModule().writerFor(type).writeValueAsString(pair));
+        Assert.assertEquals(pair, mapperWithModule().readValue(json, type));
+    }
 }


### PR DESCRIPTION
Obvious bug fix for deser of maps that have ref as both key and value - I mixed up the order :)

Looks straight-forward to merge for master as well.