### PR TITLE
Properly ignore properties on ref->ref maps with non-string keys

### DIFF
--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/SerializerTest.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/SerializerTest.java
@@ -1,11 +1,16 @@
 package com.fasterxml.jackson.datatype.eclipsecollections;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.eclipsecollections.ser.map.RefRefMapSerializer;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.eclipse.collections.api.PrimitiveIterable;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MapIterable;
@@ -158,5 +163,22 @@ public final class SerializerTest extends ModuleTestBase {
 
     private static class B extends A {
 
+    }
+
+    @Test
+    public void ignoreSerialize() throws JsonProcessingException {
+        Assert.assertEquals(
+                "{\"ecMap\":{\"2\":\"2\"}}",
+                mapperWithModule().writeValueAsString(new IgnoreSerialize())
+        );
+    }
+
+    static class IgnoreSerialize {
+        @JsonIgnoreProperties("1")
+        @JsonSerialize(as = MapIterable.class)
+        public final MapIterable<Integer, String> ecMap = Maps.immutable.of(
+                1, "1",
+                2, "2"
+        );
     }
 }


### PR DESCRIPTION
Fixes #40.

This issue also seems to be in the standard map serializer: https://github.com/FasterXML/jackson-databind/blob/2.10/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java#L751

This looks like a bit of a pain to fix, both here and in databind, since it requires us to buffer the key entirely, and let the key serializer write to that buffer. The alternative is leaving this entirely non-functional for non-string keys though, so it's probably a good idea to just add a slow path for this purpose.

My test for this bug (both here and in databind) is:

```java
    @Test
    public void ignoreSerialize() throws JsonProcessingException {
        Assert.assertEquals(
                "{\"utilMap\":{\"2\":\"2\"},\"utilStringMap\":{\"2\":\"2\"},\"ecMap\":{\"2\":\"2\"}}",
                mapperWithModule().writeValueAsString(new IgnoreSerialize())
        );
    }

    static class IgnoreSerialize {
        @JsonIgnoreProperties("1")
        public final Map<Integer, String> utilMap = new HashMap<>();

        {
            utilMap.put(1, "1");
            utilMap.put(2, "2");
        }

        @JsonIgnoreProperties("1")
        public final Map<String, String> utilStringMap = new HashMap<>();

        {
            utilStringMap.put("1", "1");
            utilStringMap.put("2", "2");
        }

        @JsonIgnoreProperties("1")
        @JsonSerialize(as = MapIterable.class)
        public final MutableMap<Integer, String> ecMap = Maps.mutable.of(
                1, "1",
                2, "2"
        );
    }
```

The current output is `{"utilMap":{"1":"1","2":"2"},"utilStringMap":{"2":"2"},"ecMap":{"1":"1","2":"2"}}` instead of the expected `{"utilMap":{"2":"2"},"utilStringMap":{"2":"2"},"ecMap":{"2":"2"}}`. It should also be noted that without `@JsonSerialize(as = MapIterable.class)`, jackson will serialize eclipse-collections ref->ref maps using the default serializers instead, since they implement java.util.Map. Also, maps involving primitives currently do not implement key ignoring at all.

This PR contains only the test for the eclipse-collections part of this issue.

@cowtowncoder , if this fix seems sane to you, I can build a similar PR for jackson-databind's `MapSerializer`.