### PR TITLE
Fix deserialization of raw ImmutableCollection types

### DIFF
--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/EclipseCollectionsDeserializers.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/EclipseCollectionsDeserializers.java
@@ -170,7 +170,8 @@ public final class EclipseCollectionsDeserializers extends Deserializers.Base {
             JsonDeserializer<?> elementDeserializer
     ) throws JsonMappingException {
         if (REFERENCE_TYPES.contains(type.getRawClass())) {
-            return findReferenceDeserializer(type, elementTypeDeserializer, elementDeserializer);
+            return findReferenceDeserializer(type, type.getContentType(),
+                                             elementTypeDeserializer, elementDeserializer);
         }
         return null;
     }
@@ -184,7 +185,8 @@ public final class EclipseCollectionsDeserializers extends Deserializers.Base {
             JsonDeserializer<?> elementDeserializer
     ) throws JsonMappingException {
         if (REFERENCE_TYPES.contains(type.getRawClass())) {
-            return findReferenceDeserializer(type, elementTypeDeserializer, elementDeserializer);
+            return findReferenceDeserializer(type, type.getContentType(),
+                                             elementTypeDeserializer, elementDeserializer);
         }
         return null;
     }
@@ -225,7 +227,7 @@ public final class EclipseCollectionsDeserializers extends Deserializers.Base {
 
         //noinspection SuspiciousMethodCalls
         if (REFERENCE_TYPES.contains(type.getRawClass())) {
-            return findReferenceDeserializer(type, null, null);
+            return findReferenceDeserializer(type, type.containedTypeOrUnknown(0), null, null);
         }
 
         EclipseMapDeserializer<?, ?, ?, ?> mapDeserializer = EclipseMapDeserializers.createDeserializer(type);
@@ -239,10 +241,11 @@ public final class EclipseCollectionsDeserializers extends Deserializers.Base {
     @SuppressWarnings({ "ObjectEquality", "LocalVariableNamingConvention", "ConstantConditions" })
     private JsonDeserializer<?> findReferenceDeserializer(
             JavaType containerType,
-            TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer
+            JavaType elementType,
+            TypeDeserializer elementTypeDeserializer,
+            JsonDeserializer<?> elementDeserializer
     ) {
         Class<?> rawClass = containerType.getRawClass();
-        JavaType elementType = containerType.containedType(0);
 
         // bags
         if (rawClass == MutableBag.class || rawClass == Bag.class || rawClass == UnsortedBag.class) {

--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/EclipseCollectionsTypeModifier.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/EclipseCollectionsTypeModifier.java
@@ -14,7 +14,7 @@ class EclipseCollectionsTypeModifier extends TypeModifier {
         if (!type.isCollectionLikeType()) {
             JavaType collectionType = type.findSuperType(ImmutableCollection.class);
             if (collectionType != null) {
-                return CollectionLikeType.upgradeFrom(type, collectionType.containedType(0));
+                return CollectionLikeType.upgradeFrom(type, collectionType.containedTypeOrUnknown(0));
             }
         }
         return type;

--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
@@ -316,6 +316,10 @@ public final class DeserializerTest extends ModuleTestBase {
         testCollection(Lists.mutable.of("1", "2", "3"),
                        "[\"1\", \"2\", \"3\"]",
                        new TypeReference<MutableCollection<String>>() {});
+        //noinspection rawtypes
+        testCollection(Lists.mutable.of("1", "2", "3"),
+                       "[\"1\", \"2\", \"3\"]",
+                       new TypeReference<MutableCollection>() {});
         testCollection(BooleanLists.mutable.of(true, false, true),
                        "[true, false, true]",
                        MutableBooleanCollection.class);
@@ -335,6 +339,10 @@ public final class DeserializerTest extends ModuleTestBase {
         testCollection(Lists.immutable.of("1", "2", "3"),
                        "[\"1\", \"2\", \"3\"]",
                        new TypeReference<ImmutableCollection<String>>() {});
+        //noinspection rawtypes
+        testCollection(Lists.immutable.of("1", "2", "3"),
+                       "[\"1\", \"2\", \"3\"]",
+                       new TypeReference<ImmutableCollection>() {});
         testCollection(BooleanLists.immutable.of(true, false, true),
                        "[true, false, true]",
                        ImmutableBooleanCollection.class);


### PR DESCRIPTION
This fixes the last test failure in master. The reason for this test failure was that `type.findSuperType(ImmutableCollection.class).containedType(0)` returns `null` when type is the raw `ImmutableCollection` type (it worked fine for the raw `ImmutableList` type).

This change also adds test cases for raw types that make this bug appear in 2.x.