### PR TITLE
Add support for Guava's Immutable{Double,Int,Long}Array during serialization/deserialization

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.guava;
 
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
 import com.fasterxml.jackson.datatype.guava.util.PrimitiveTypes;
 import com.google.common.base.Optional;
 import com.google.common.collect.*;
@@ -21,8 +22,6 @@ import com.fasterxml.jackson.datatype.guava.deser.multimap.set.HashMultimapDeser
 import com.fasterxml.jackson.datatype.guava.deser.multimap.set.LinkedHashMultimapDeserializer;
 
 import java.io.Serializable;
-
-import static com.fasterxml.jackson.datatype.guava.util.PrimitiveTypes.isAssignableFromPrimitive;
 
 /**
  * Custom deserializers module offers.
@@ -130,7 +129,7 @@ public class GuavaDeserializers
                     null, null);
         }
 
-        return isAssignableFromPrimitive(raw)
+        return PrimitiveTypes.isAssignableFromPrimitive(raw)
                 .transform(PrimitiveTypes.Primitives::newDeserializer)
                 .orNull();
     }
@@ -298,7 +297,9 @@ public class GuavaDeserializers
         if (type.hasRawClass(HashCode.class)) {
             return HashCodeDeserializer.std;
         }
-        return null;
+        return ImmutablePrimitiveTypes.isAssignableFromImmutableArray(type.getRawClass())
+                .transform(ImmutablePrimitiveTypes.ImmutablePrimitiveArrays::newDeserializer)
+                .orNull();
     }
 
     @Override
@@ -315,7 +316,8 @@ public class GuavaDeserializers
                     || ImmutableCollection.class.isAssignableFrom(valueType)
                     || ImmutableMap.class.isAssignableFrom(valueType)
                     || BiMap.class.isAssignableFrom(valueType)
-                    || isAssignableFromPrimitive(valueType).isPresent()
+                    || PrimitiveTypes.isAssignableFromPrimitive(valueType).isPresent()
+                    || ImmutablePrimitiveTypes.isAssignableFromImmutableArray(valueType).isPresent()
                     ;
         }
         return false;

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.datatype.guava;
 
 import com.fasterxml.jackson.databind.type.CollectionLikeType;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
 import com.fasterxml.jackson.datatype.guava.util.PrimitiveTypes;
 import java.io.Serializable;
 import java.util.Set;
@@ -95,7 +96,9 @@ public class GuavaSerializers extends Serializers.Base
             JavaType iterableType = _findDeclared(type, Iterable.class);
             return new StdDelegatingSerializer(FluentConverter.instance, iterableType, null, null);
         }
-        return null;
+        return ImmutablePrimitiveTypes.isAssignableFromImmutableArray(raw)
+                .transform(ImmutablePrimitiveTypes.ImmutablePrimitiveArrays::newSerializer)
+                .orNull();
     }
 
     @Override

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/BaseImmutableArrayDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/BaseImmutableArrayDeserializer.java
@@ -1,0 +1,23 @@
+package com.fasterxml.jackson.datatype.guava.deser.primitives;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.datatype.guava.deser.BasePrimitiveCollectionDeserializer;
+
+public abstract class BaseImmutableArrayDeserializer<ObjectType, ImmutablePrimitiveArray, IntermediateArrayBuilder>
+        extends BasePrimitiveCollectionDeserializer<ObjectType, ImmutablePrimitiveArray, IntermediateArrayBuilder> {
+
+    protected BaseImmutableArrayDeserializer(Class<? extends ImmutablePrimitiveArray> cls, Class<? super ObjectType> itemType) {
+        super(cls, itemType);
+    }
+
+    @Override
+    protected final void add(IntermediateArrayBuilder intermediateBuilder, JsonParser parser, DeserializationContext context) throws JacksonException {
+        collect(intermediateBuilder, asPrimitive(parser));
+    }
+
+    protected abstract void collect(IntermediateArrayBuilder intermediateBuilder, ObjectType value);
+
+    protected abstract ObjectType asPrimitive(JsonParser parser) throws JacksonException;
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/ImmutableDoubleArrayDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/ImmutableDoubleArrayDeserializer.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.datatype.guava.deser.primitives;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
+import com.google.common.primitives.ImmutableDoubleArray;
+
+public class ImmutableDoubleArrayDeserializer
+        extends BaseImmutableArrayDeserializer<Double, ImmutableDoubleArray, ImmutableDoubleArray.Builder> {
+    public ImmutableDoubleArrayDeserializer() {
+        super(ImmutablePrimitiveTypes.ImmutableDoubleArrayType, Double.class);
+    }
+
+    @Override
+    protected ImmutableDoubleArray.Builder createIntermediateCollection() {
+        return ImmutableDoubleArray.builder();
+    }
+
+    @Override
+    protected void collect(ImmutableDoubleArray.Builder intermediateBuilder, Double value) {
+        intermediateBuilder.add(value);
+    }
+
+    @Override
+    protected ImmutableDoubleArray finish(ImmutableDoubleArray.Builder builder) {
+        return builder.build();
+    }
+
+    @Override
+    protected Double asPrimitive(JsonParser parser) throws JacksonException {
+        return parser.getDoubleValue();
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/ImmutableIntArrayDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/ImmutableIntArrayDeserializer.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.datatype.guava.deser.primitives;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
+import com.google.common.primitives.ImmutableIntArray;
+
+public class ImmutableIntArrayDeserializer
+        extends BaseImmutableArrayDeserializer<Integer, ImmutableIntArray, ImmutableIntArray.Builder> {
+    public ImmutableIntArrayDeserializer() {
+        super(ImmutablePrimitiveTypes.ImmutableIntArrayType, Integer.class);
+    }
+
+    @Override
+    protected ImmutableIntArray.Builder createIntermediateCollection() {
+        return ImmutableIntArray.builder();
+    }
+
+    @Override
+    protected void collect(ImmutableIntArray.Builder intermediateBuilder, Integer value) {
+        intermediateBuilder.add(value);
+    }
+
+    @Override
+    protected ImmutableIntArray finish(ImmutableIntArray.Builder builder) {
+        return builder.build();
+    }
+
+    @Override
+    protected Integer asPrimitive(JsonParser parser) throws JacksonException {
+        return parser.getIntValue();
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/ImmutableLongArrayDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/primitives/ImmutableLongArrayDeserializer.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.datatype.guava.deser.primitives;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
+import com.google.common.primitives.ImmutableLongArray;
+
+public class ImmutableLongArrayDeserializer
+        extends BaseImmutableArrayDeserializer<Long, ImmutableLongArray, ImmutableLongArray.Builder> {
+    public ImmutableLongArrayDeserializer() {
+        super(ImmutablePrimitiveTypes.ImmutableLongArrayType, Long.class);
+    }
+
+    @Override
+    protected ImmutableLongArray.Builder createIntermediateCollection() {
+        return ImmutableLongArray.builder();
+    }
+
+    @Override
+    protected void collect(ImmutableLongArray.Builder intermediateBuilder, Long value) {
+        intermediateBuilder.add(value);
+    }
+
+    @Override
+    protected ImmutableLongArray finish(ImmutableLongArray.Builder builder) {
+        return builder.build();
+    }
+
+    @Override
+    protected Long asPrimitive(JsonParser parser) throws JacksonException {
+        return parser.getLongValue();
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/BaseImmutableArraySerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/BaseImmutableArraySerializer.java
@@ -1,0 +1,24 @@
+package com.fasterxml.jackson.datatype.guava.ser.primitives;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
+
+public abstract class BaseImmutableArraySerializer<ImmutableArray> extends StdSerializer<ImmutableArray> {
+    protected BaseImmutableArraySerializer(ImmutablePrimitiveTypes.ImmutablePrimitiveArrays immutableArrayType) {
+        super(immutableArrayType.type());
+    }
+
+    @Override
+    public final void serialize(ImmutableArray immutableArray, JsonGenerator gen, SerializerProvider provider) throws JacksonException {
+        if (immutableArray == null) {
+            provider.defaultSerializeNullValue(gen);
+        } else {
+            writeArray(immutableArray, gen);
+        }
+    }
+
+    protected abstract void writeArray(ImmutableArray immutableArray, JsonGenerator gen);
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/ImmutableDoubleArraySerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/ImmutableDoubleArraySerializer.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.datatype.guava.ser.primitives;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
+import com.google.common.primitives.ImmutableDoubleArray;
+
+public class ImmutableDoubleArraySerializer extends BaseImmutableArraySerializer<ImmutableDoubleArray> {
+
+    public ImmutableDoubleArraySerializer() {
+        super(ImmutablePrimitiveTypes.ImmutablePrimitiveArrays.DOUBLE);
+    }
+
+    @Override
+    protected void writeArray(ImmutableDoubleArray immutableArray, JsonGenerator gen) {
+        if (!immutableArray.isEmpty()) {
+            gen.writeArray(immutableArray.toArray(), 0, immutableArray.length());
+        }
+    }
+
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/ImmutableIntArraySerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/ImmutableIntArraySerializer.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.datatype.guava.ser.primitives;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
+import com.google.common.primitives.ImmutableIntArray;
+
+public class ImmutableIntArraySerializer extends BaseImmutableArraySerializer<ImmutableIntArray> {
+
+    public ImmutableIntArraySerializer() {
+        super(ImmutablePrimitiveTypes.ImmutablePrimitiveArrays.INT);
+    }
+
+    @Override
+    protected void writeArray(ImmutableIntArray immutableArray, JsonGenerator gen) {
+        if (!immutableArray.isEmpty()) {
+            gen.writeArray(immutableArray.toArray(), 0, immutableArray.length());
+        }
+    }
+
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/ImmutableLongArraySerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/primitives/ImmutableLongArraySerializer.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.datatype.guava.ser.primitives;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.datatype.guava.util.ImmutablePrimitiveTypes;
+import com.google.common.primitives.ImmutableLongArray;
+
+public class ImmutableLongArraySerializer extends BaseImmutableArraySerializer<ImmutableLongArray> {
+
+    public ImmutableLongArraySerializer() {
+        super(ImmutablePrimitiveTypes.ImmutablePrimitiveArrays.LONG);
+    }
+
+    @Override
+    protected void writeArray(ImmutableLongArray immutableArray, JsonGenerator gen) {
+        if (!immutableArray.isEmpty()) {
+            gen.writeArray(immutableArray.toArray(), 0, immutableArray.length());
+        }
+    }
+
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/util/ImmutablePrimitiveTypes.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/util/ImmutablePrimitiveTypes.java
@@ -1,0 +1,115 @@
+package com.fasterxml.jackson.datatype.guava.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.datatype.guava.deser.primitives.BaseImmutableArrayDeserializer;
+import com.fasterxml.jackson.datatype.guava.deser.primitives.ImmutableDoubleArrayDeserializer;
+import com.fasterxml.jackson.datatype.guava.deser.primitives.ImmutableIntArrayDeserializer;
+import com.fasterxml.jackson.datatype.guava.deser.primitives.ImmutableLongArrayDeserializer;
+import com.fasterxml.jackson.datatype.guava.ser.primitives.BaseImmutableArraySerializer;
+import com.fasterxml.jackson.datatype.guava.ser.primitives.ImmutableDoubleArraySerializer;
+import com.fasterxml.jackson.datatype.guava.ser.primitives.ImmutableIntArraySerializer;
+import com.fasterxml.jackson.datatype.guava.ser.primitives.ImmutableLongArraySerializer;
+import com.google.common.base.Optional;
+import com.google.common.primitives.ImmutableDoubleArray;
+import com.google.common.primitives.ImmutableIntArray;
+import com.google.common.primitives.ImmutableLongArray;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+import static com.fasterxml.jackson.datatype.guava.util.PrimitiveTypes.typeRefOf;
+
+/**
+ * Utility class to cover all {@code Immutable[Primitive]Array} primitive types
+ *
+ * @author robert@albertlr.ro
+ */
+public class ImmutablePrimitiveTypes {
+    /**
+     * An enum with all the primitives
+     */
+    public enum ImmutablePrimitiveArrays {
+        INT(ImmutableIntArrayType, int.class, Integer.class,
+                ImmutableIntArraySerializer::new,
+                ImmutableIntArrayDeserializer::new
+        ),
+        DOUBLE(ImmutableDoubleArrayType, double.class, Double.class,
+                ImmutableDoubleArraySerializer::new,
+                ImmutableDoubleArrayDeserializer::new
+        ),
+        LONG(ImmutableLongArrayType, long.class, Long.class,
+                ImmutableLongArraySerializer::new,
+                ImmutableLongArrayDeserializer::new
+        );
+
+        private final Class<?> type;
+        private final Class<?> primitiveType;
+        private final Class<?> objectType;
+        private final Supplier<? extends BaseImmutableArraySerializer> serializerFactory;
+        private final Supplier<? extends BaseImmutableArrayDeserializer> deserializerFactory;
+
+        private ImmutablePrimitiveArrays(Class<?> type, Class<?> primitiveType, Class<?> objectType,
+                                         Supplier<? extends BaseImmutableArraySerializer> serializerFactory,
+                                         Supplier<? extends BaseImmutableArrayDeserializer> deserializerFactory) {
+            this.type = type;
+            this.primitiveType = primitiveType;
+            this.objectType = objectType;
+            this.deserializerFactory = deserializerFactory;
+            this.serializerFactory = serializerFactory;
+        }
+
+        public Class<?> type() {
+            return type;
+        }
+
+        public Class<?> primitiveType() {
+            return primitiveType;
+        }
+
+        public <T> Class<T> objectType() {
+            return (Class<T>) objectType;
+        }
+
+        public <T extends Serializable> BaseImmutableArraySerializer<T> newSerializer() {
+            return serializerFactory.get();
+        }
+
+        public <T> StdDeserializer<T> newDeserializer() {
+            return deserializerFactory.get();
+        }
+
+    }
+
+    public static Optional<ImmutablePrimitiveTypes.ImmutablePrimitiveArrays> isAssignableFromImmutableArray(Class<?> immutableArrayType) {
+        for (ImmutablePrimitiveArrays primitive : ImmutablePrimitiveArrays.values()) {
+            if (primitive.type().isAssignableFrom(immutableArrayType)) {
+                return Optional.of(primitive);
+            }
+        }
+        return Optional.absent();
+    }
+
+
+    /**
+     * Type of array returned by {@link ImmutableIntArray}
+     */
+    public static final Class<? extends ImmutableIntArray> ImmutableIntArrayType = ImmutableIntArray.class;
+    /**
+     * Type of array returned by {@link ImmutableLongArray}
+     */
+    public static final Class<? extends ImmutableLongArray> ImmutableLongArrayType = ImmutableLongArray.class;
+    /**
+     * Type of array returned by {@link ImmutableDoubleArray}
+     */
+    public static final Class<? extends ImmutableDoubleArray> ImmutableDoubleArrayType = ImmutableDoubleArray.class;
+
+    public static final TypeReference<ImmutableIntArray> ImmutableIntArrayReference = typeRefOf(ImmutableIntArrayType);
+    public static final TypeReference<ImmutableLongArray> ImmutableLongArrayReference = typeRefOf(ImmutableLongArrayType);
+    public static final TypeReference<ImmutableDoubleArray> ImmutableDoubleArrayReference = typeRefOf(ImmutableDoubleArrayType);
+
+    public static final String ImmutableIntArrayName = ImmutableIntArrayType.getName();
+    public static final String ImmutableLongArrayName = ImmutableLongArrayType.getName();
+    public static final String ImmutableDoubleArrayName = ImmutableDoubleArrayType.getName();
+
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/util/PrimitiveTypes.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/util/PrimitiveTypes.java
@@ -131,12 +131,11 @@ public class PrimitiveTypes {
     public static final String LongsTypeName = LongsType.getName();
     public static final String ShortsTypeName = ShortsType.getName();
 
-
-    private static <T> TypeReference<T> typeRefOf(Type type) {
+    static <T> TypeReference<T> typeRefOf(Type type) {
         return new PrimitiveTypeReference<>(type);
     }
 
-    private static class PrimitiveTypeReference<T> extends TypeReference<T> {
+    static class PrimitiveTypeReference<T> extends TypeReference<T> {
         private final Type primitiveType;
 
         private PrimitiveTypeReference(Type primitiveType) {


### PR DESCRIPTION
Add support to serialize and deserialize Guava's `Immutable{Double,Int,Long}Array` as requested in #24 .
* [ImmutableDoubleArray](https://google.github.io/guava/releases/22.0/api/docs/com/google/common/primitives/ImmutableDoubleArray.html)
* [ImmutableIntArray](https://google.github.io/guava/releases/22.0/api/docs/com/google/common/primitives/ImmutableIntArray.html)
* [ImmutableLongArray](https://google.github.io/guava/releases/22.0/api/docs/com/google/common/primitives/ImmutableLongArray.html)
 
These _primitives_ were not part of primitive support added in #69 