### PR TITLE
Fix serialization of pair/triple classes

### DIFF
--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -27,7 +27,7 @@
     </contributors>
 
     <properties>
-        <version.eclipse-collections>9.1.0</version.eclipse-collections>
+        <version.eclipse-collections>11.0.0</version.eclipse-collections>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/datatype/eclipsecollections</packageVersion.dir>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
-            <version>10.4.0</version>
+            <version>${version.eclipse-collections}</version>
         </dependency>
     </dependencies>
 

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -27,7 +27,7 @@
     </contributors>
 
     <properties>
-        <version.eclipse-collections>11.0.0</version.eclipse-collections>
+        <version.eclipse-collections>10.4.0</version.eclipse-collections>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/datatype/eclipsecollections</packageVersion.dir>

--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/EclipseCollectionsModule.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/EclipseCollectionsModule.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.datatype.eclipsecollections.deser.pair.PairInstantiators;
 import com.fasterxml.jackson.datatype.eclipsecollections.deser.pair.TripleInstantiators;
+import org.eclipse.collections.api.tuple.Triple;
 
 /**
  * Basic Jackson {@link Module} that adds support for eclipse-collections types.
@@ -33,11 +34,16 @@ public class EclipseCollectionsModule extends Module {
         context.addValueInstantiators(new PairInstantiators());
         try {
             context.addValueInstantiators(new TripleInstantiators());
+            context.setMixInAnnotations(Triple.class, TripleMixin.class);
         } catch (NoClassDefFoundError ignored) {
             // triples were added in EC 10
         }
 
         context.addTypeModifier(new EclipseCollectionsTypeModifier());
+
+        for (Class<?> pairClass : PairInstantiators.getAllPairClasses()) {
+            context.setMixInAnnotations(pairClass, PairMixin.class);
+        }
     }
 
     @Override

--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/PairMixin.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/PairMixin.java
@@ -1,0 +1,7 @@
+package com.fasterxml.jackson.datatype.eclipsecollections;
+
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+
+@JsonIncludeProperties({"one", "two"})
+class PairMixin {
+}

--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/TripleMixin.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/TripleMixin.java
@@ -1,0 +1,7 @@
+package com.fasterxml.jackson.datatype.eclipsecollections;
+
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+
+@JsonIncludeProperties({"one", "two", "three"})
+class TripleMixin {
+}

--- a/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/deser/pair/PairInstantiators.java
+++ b/eclipse-collections/src/main/java/com/fasterxml/jackson/datatype/eclipsecollections/deser/pair/PairInstantiators.java
@@ -1,7 +1,10 @@
 package com.fasterxml.jackson.datatype.eclipsecollections.deser.pair;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -104,6 +107,12 @@ import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
  */
 public final class PairInstantiators extends ValueInstantiators.Base {
     private static final Map<Class<?>, ValueInstantiator> PURE_PRIMITIVE_INSTANTIATORS = new HashMap<>();
+
+    private static final List<Class<?>> ALL_PAIR_CLASSES;
+
+    public static List<Class<?>> getAllPairClasses() {
+        return ALL_PAIR_CLASSES;
+    }
 
     @SuppressWarnings("serial")
     @Override
@@ -462,5 +471,30 @@ public final class PairInstantiators extends ValueInstantiators.Base {
         purePrimitiveInstantiator(DoubleDoublePair.class, double.class, double.class,
                                   (one, two) -> PrimitiveTuples.pair((double) one, (double) two));
         //endregion
+
+        List<Class<?>> allPairClasses = new ArrayList<>(PURE_PRIMITIVE_INSTANTIATORS.keySet());
+        // primitive -> object
+        allPairClasses.add(BooleanObjectPair.class);
+        allPairClasses.add(ByteObjectPair.class);
+        allPairClasses.add(ShortObjectPair.class);
+        allPairClasses.add(CharObjectPair.class);
+        allPairClasses.add(IntObjectPair.class);
+        allPairClasses.add(FloatObjectPair.class);
+        allPairClasses.add(LongObjectPair.class);
+        allPairClasses.add(DoubleObjectPair.class);
+        // object -> primitive
+        allPairClasses.add(ObjectBooleanPair.class);
+        allPairClasses.add(ObjectBytePair.class);
+        allPairClasses.add(ObjectShortPair.class);
+        allPairClasses.add(ObjectCharPair.class);
+        allPairClasses.add(ObjectIntPair.class);
+        allPairClasses.add(ObjectFloatPair.class);
+        allPairClasses.add(ObjectLongPair.class);
+        allPairClasses.add(ObjectDoublePair.class);
+        // object -> object
+        allPairClasses.add(Pair.class);
+        allPairClasses.add(Twin.class);
+
+        ALL_PAIR_CLASSES = Collections.unmodifiableList(allPairClasses);
     }
 }


### PR DESCRIPTION
This broke in eclipse-collections 11 with the introduction of the `isSame` and `isEqual` methods on the pair/triple classes. This patch adds mixins to those classes that use `@JsonIncludeProperties` to only allow the expected properties.

Fixes #94