### PR TITLE
[Guava] Suppport simple deserialization of `Cache`

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -287,9 +287,11 @@ public class GuavaDeserializers
         DeserializationConfig config, BeanDescription beanDesc, KeyDeserializer keyDeserializer, 
         TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer) 
     {
+        /* // Example implementations
         if (LoadingCache.class.isAssignableFrom(raw)) {
-            // TODO: 
+            return ....your implementation....;
         }
+        */
         if (Cache.class.isAssignableFrom(raw)) {
             return java.util.Optional.of(
                 new SimpleCacheDeserializer(type, keyDeserializer, elementTypeDeserializer, elementDeserializer));

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -263,7 +263,7 @@ public class GuavaDeserializers
         if (Table.class.isAssignableFrom(raw)) {
             // !!! TODO
         }
-
+        // @since 2.16 : support Cache deserialization
         java.util.Optional<JsonDeserializer<?>> cacheDeserializer = findCacheDeserializer(raw, type, config, 
                                         beanDesc, keyDeserializer, elementTypeDeserializer, elementDeserializer);
         if (cacheDeserializer.isPresent()) {

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -1,6 +1,9 @@
 package com.fasterxml.jackson.datatype.guava;
 
 import com.google.common.base.Optional;
+import com.google.common.cache.Cache;
+import com.google.common.cache.ForwardingCache;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.*;
 import com.google.common.hash.HashCode;
 import com.google.common.net.HostAndPort;
@@ -261,7 +264,37 @@ public class GuavaDeserializers
             // !!! TODO
         }
 
+        java.util.Optional<JsonDeserializer<?>> cacheDeserializer = findCacheDeserializer(raw, type, config, 
+                                        beanDesc, keyDeserializer, elementTypeDeserializer, elementDeserializer);
+        if (cacheDeserializer.isPresent()) {
+            return cacheDeserializer.get();
+        }
+
         return null;
+    }
+
+    /**
+     * Find matching implementation of {@link Cache} deserializers by checking
+     * if the parameter {@code raw} type is assignable.
+     *
+     * NOTE: Make sure the cache implementations are checked in such a way that more concrete classes are
+     * compared first before more abstract ones.
+     *
+     * @return An optional {@link JsonDeserializer} for the cache type, if found.
+     * @since 2.16
+     */
+    private java.util.Optional<JsonDeserializer<?>> findCacheDeserializer(Class<?> raw, MapLikeType type, 
+        DeserializationConfig config, BeanDescription beanDesc, KeyDeserializer keyDeserializer, 
+        TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer) 
+    {
+        if (LoadingCache.class.isAssignableFrom(raw)) {
+            // TODO: 
+        }
+        if (Cache.class.isAssignableFrom(raw)) {
+            return java.util.Optional.of(
+                new SimpleCacheDeserializer(type, keyDeserializer, elementTypeDeserializer, elementDeserializer));
+        }
+        return java.util.Optional.empty();
     }
 
     @Override // since 2.7

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/SimpleCacheDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/SimpleCacheDeserializer.java
@@ -9,6 +9,11 @@ import com.fasterxml.jackson.datatype.guava.deser.cache.GuavaCacheDeserializer;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+/**
+ * {@link GuavaCacheDeserializer} class implementation for deserializing Guava {@link Cache} instances.
+ *
+ * @since 2.16
+ */
 public class SimpleCacheDeserializer 
     extends GuavaCacheDeserializer<Cache<Object,Object>> 
 {

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/SimpleCacheDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/SimpleCacheDeserializer.java
@@ -1,0 +1,52 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.deser.NullValueProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.type.MapLikeType;
+import com.fasterxml.jackson.datatype.guava.deser.cache.GuavaCacheDeserializer;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+public class SimpleCacheDeserializer 
+    extends GuavaCacheDeserializer<Cache<Object,Object>> 
+{
+    
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+    public SimpleCacheDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
+        TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer) 
+    {
+        super(type, keyDeserializer, elementTypeDeserializer, elementDeserializer);
+    }
+
+    public SimpleCacheDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
+        TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer,
+        NullValueProvider nvp) 
+    {
+        super(type, keyDeserializer, elementTypeDeserializer, elementDeserializer, nvp);
+    }
+    
+    /*
+    /**********************************************************************
+    /* Abstract method overrides
+    /**********************************************************************
+     */
+
+    @Override
+    protected Cache<Object, Object> createCache() {
+        return CacheBuilder.newBuilder().build();
+    }
+
+    @Override
+    protected JsonDeserializer<?> _createContextual(MapLikeType t, 
+        KeyDeserializer kd, TypeDeserializer vtd, JsonDeserializer<?> vd, NullValueProvider np) 
+    {
+        return new SimpleCacheDeserializer(t, kd, vtd, vd, np);
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/cache/GuavaCacheDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/cache/GuavaCacheDeserializer.java
@@ -109,11 +109,6 @@ public abstract class GuavaCacheDeserializer<T extends Cache<Object, Object>>
 
     @Override
     public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        //check if ACCEPT_SINGLE_VALUE_AS_ARRAY feature is enabled
-//        if (ctxt.isEnabled(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)) {
-//            return deserializeFromSingleValue(p, ctxt);
-//        }
-        // if not deserialize the normal way
         return deserializeContents(p, ctxt);
     }
 

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/cache/GuavaCacheDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/cache/GuavaCacheDeserializer.java
@@ -1,0 +1,166 @@
+package com.fasterxml.jackson.datatype.guava.deser.cache;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.NullValueProvider;
+import com.fasterxml.jackson.databind.deser.impl.NullsConstantProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.type.LogicalType;
+import com.fasterxml.jackson.databind.type.MapLikeType;
+import com.google.common.cache.Cache;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+public abstract class GuavaCacheDeserializer<T extends Cache<Object, Object>> 
+    extends StdDeserializer<T> implements ContextualDeserializer 
+{
+    private static final long serialVersionUID = 1L;
+
+    private final MapLikeType type;
+    private final KeyDeserializer keyDeserializer;
+    private final TypeDeserializer elementTypeDeserializer;
+    private final JsonDeserializer<?> elementDeserializer;
+    
+    /*
+     * @since 2.16 : in 3.x demote to `ContainerDeserializerBase`
+     */
+    private final NullValueProvider nullProvider;
+    private final boolean skipNullValues;
+    
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+    public GuavaCacheDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
+            TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer) {
+        this(type, keyDeserializer, elementTypeDeserializer, elementDeserializer, null);
+    }
+    
+    public GuavaCacheDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
+            TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer,
+            NullValueProvider nvp)
+    {
+        super(type);
+        this.type = type;
+        this.keyDeserializer = keyDeserializer;
+        this.elementTypeDeserializer = elementTypeDeserializer;
+        this.elementDeserializer = elementDeserializer;
+        this.nullProvider = nvp;
+        skipNullValues = (nvp == null) ? false : NullsConstantProvider.isSkipper(nvp);
+    }
+    
+    /*
+    /**********************************************************
+    /* Post-processing (contextualization)
+    /**********************************************************
+     */
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
+            BeanProperty property) throws JsonMappingException 
+    {
+        KeyDeserializer kd = keyDeserializer;
+        if (kd == null) {
+            kd = ctxt.findKeyDeserializer(type.getKeyType(), property);
+        }
+        JsonDeserializer<?> valueDeser = elementDeserializer;
+        final JavaType vt = type.getContentType();
+        if (valueDeser == null) {
+            valueDeser = ctxt.findContextualValueDeserializer(vt, property);
+        } else { // if directly assigned, probably not yet contextual, so:
+            valueDeser = ctxt.handleSecondaryContextualization(valueDeser, property, vt);
+        }
+        // Type deserializer is slightly different; must be passed, but needs to become contextual:
+        TypeDeserializer vtd = elementTypeDeserializer;
+        if (vtd != null) {
+            vtd = vtd.forProperty(property);
+        }
+        return _createContextual(type, kd, vtd, valueDeser, 
+                findContentNullProvider(ctxt, property, valueDeser));
+    }
+    
+    /*
+    /**********************************************************************
+    /* Abstract methods for subclasses
+    /**********************************************************************
+     */
+
+    protected abstract T createCache();
+
+    protected abstract JsonDeserializer<?> _createContextual(MapLikeType t, KeyDeserializer kd,
+            TypeDeserializer vtd, JsonDeserializer<?> vd, NullValueProvider np);
+    
+    /*
+    /**********************************************************************
+    /* Implementations
+    /**********************************************************************
+     */
+
+    @Override
+    public LogicalType logicalType() {
+        return LogicalType.Map;
+    }
+
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        //check if ACCEPT_SINGLE_VALUE_AS_ARRAY feature is enabled
+//        if (ctxt.isEnabled(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)) {
+//            return deserializeFromSingleValue(p, ctxt);
+//        }
+        // if not deserialize the normal way
+        return deserializeContents(p, ctxt);
+    }
+
+    private T deserializeContents(JsonParser p, DeserializationContext ctxt)
+        throws IOException
+    {
+        T cache = createCache();
+        
+        JsonToken currToken = p.currentToken();
+        if (currToken != JsonToken.FIELD_NAME) {
+            // 01-Mar-2023, tatu: [datatypes-collections#104] Handle empty Maps too
+            if (currToken != JsonToken.END_OBJECT) {
+                expect(p, JsonToken.START_OBJECT);
+                currToken = p.nextToken();
+            }
+        }
+        
+        for (; currToken == JsonToken.FIELD_NAME; currToken = p.nextToken()) {
+            final Object key;
+            if (keyDeserializer != null) {
+                key = keyDeserializer.deserializeKey(p.currentName(), ctxt);
+            } else {
+                key = p.currentName();
+            }
+            
+            p.nextToken();
+            
+            final Object value;
+            if (p.currentToken() == JsonToken.VALUE_NULL) {
+                if (skipNullValues) {
+                    continue;
+                }
+                value = nullProvider.getNullValue(ctxt);
+            } else if (elementTypeDeserializer != null) {
+                value = elementDeserializer.deserializeWithType(p, ctxt, elementTypeDeserializer);
+            } else {
+                value = elementDeserializer.deserialize(p, ctxt);
+            }
+            cache.put(key, value);
+        }
+        return cache;
+    }
+
+    private void expect(JsonParser p, JsonToken token) throws IOException {
+        if (p.getCurrentToken() != token) {
+            throw new JsonMappingException(p, "Expecting " + token + " to start `Cache` value, found " + p.currentToken(),
+                p.getCurrentLocation());
+        }
+    }
+}

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/CacheDeserializationTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/CacheDeserializationTest.java
@@ -82,10 +82,10 @@ public class CacheDeserializationTest extends ModuleTestBase {
 
     public void testCacheDeserializationSimple() throws Exception {
         // Create a delegate cache using CacheBuilder
-        Cache<String, Integer> delegateCache = CacheBuilder.newBuilder().maximumSize(2).build();
+        Cache<String, Integer> delegateCache = CacheBuilder.newBuilder().build();
         delegateCache.put("key1", 1);
 
-        Cache<String, String> s = MAPPER.readValue(a2q("{'cache':{'a':'foo'}}"),
+        Cache<String, String> s = MAPPER.readValue(a2q("{'a':'foo'}"),
             new TypeReference<Cache<String, String>>() {});
 
         assertEquals(1, s.size());
@@ -134,14 +134,18 @@ public class CacheDeserializationTest extends ModuleTestBase {
     public void testEnumKey() throws Exception {
         final TypeReference<Cache<MyEnum, Integer>> type = new TypeReference<Cache<MyEnum, Integer>>() {};
         final Cache<MyEnum, Integer> cache = CacheBuilder.newBuilder().build();
-
         cache.put(MyEnum.YAY, 5);
         cache.put(MyEnum.BOO, 2);
 
+        // test serialization
         final String serializedForm = MAPPER.writerFor(type).writeValueAsString(cache);
-
         assertEquals(serializedForm, MAPPER.writeValueAsString(cache));
-        assertEquals(cache, MAPPER.readValue(serializedForm, type));
+        
+        // test deserialization
+        final Cache<MyEnum, Integer> deserializedCache = MAPPER.readValue(serializedForm, type);
+        assertEquals(
+            cache.asMap().entrySet(),
+            deserializedCache.asMap().entrySet());
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/CacheDeserializationTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/CacheDeserializationTest.java
@@ -1,0 +1,175 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Unit tests for verifying deserialization of Guava's {@link Cache} type.
+ *
+ * @since 2.16
+ */
+public class CacheDeserializationTest extends ModuleTestBase {
+
+    /*
+    /**********************************************************
+    /* Set up
+    /**********************************************************
+     */
+
+    // [datatype-collections#96]
+    static class CacheProperties {
+        @JsonProperty
+        Cache<Long, Integer> cache;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public CacheProperties(@JsonProperty("cache") Cache<Long, Integer> cache) {
+            this.cache = cache;
+        }
+    }
+
+    // [datatype-collections#96]
+    static class CacheDelegating {
+        Cache<Long, Integer> cache;
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public CacheDelegating(Cache<Long, Integer> cache) {
+            this.cache = cache;
+        }
+
+        @JsonValue
+        Cache<Long, Integer> mapValue() {
+            return cache;
+        }
+    }
+
+    private enum MyEnum {
+        YAY,
+        BOO
+    }
+    
+    /*
+    /**********************************************************
+    /* Tests
+    /**********************************************************
+     */
+
+    private final ObjectMapper MAPPER = mapperWithModule();
+
+    public void testGuavaCacheApi() throws Exception {
+        Cache<String, String> cache = CacheBuilder.newBuilder().build();
+        // Cache does not allow null key
+        try {
+            cache.put(null, "value");
+            fail("should not pass");
+        } catch (NullPointerException e) {}
+
+        // Cache does not allow null value
+        try {
+            cache.put("key", null);
+            fail("should not pass");
+        } catch (NullPointerException e) {}
+    }
+
+    public void testCacheDeserializationSimple() throws Exception {
+        // Create a delegate cache using CacheBuilder
+        Cache<String, Integer> delegateCache = CacheBuilder.newBuilder().maximumSize(2).build();
+        delegateCache.put("key1", 1);
+
+        Cache<String, String> s = MAPPER.readValue(a2q("{'cache':{'a':'foo'}}"),
+            new TypeReference<Cache<String, String>>() {});
+
+        assertEquals(1, s.size());
+        assertEquals("foo", s.getIfPresent("a"));
+    }
+
+    public void testCacheDeserRoundTrip() throws Exception {
+        Cache<String, Integer> cache = CacheBuilder.newBuilder().build();
+        cache.put("key1", 1);
+        cache.put("key2", 2);
+        String json = MAPPER.writeValueAsString(cache);
+
+        Cache<String, Integer> deserializedCache = MAPPER.readValue(json,
+            new TypeReference<Cache<String, Integer>>() {});
+
+        int value1 = Objects.requireNonNull(deserializedCache.getIfPresent("key1"));
+        int value2 = Objects.requireNonNull(deserializedCache.getIfPresent("key2"));
+        assertEquals(1, value1);
+        assertEquals(2, value2);
+    }
+
+    // [datatype-collections#96]
+    public void testCacheSerialization() throws Exception {
+        Cache<Long, Integer> cache = CacheBuilder.newBuilder().build();
+        cache.put(1L, 1);
+        cache.put(2L, 2);
+
+        // properties
+        String json = MAPPER.writeValueAsString(new CacheProperties(cache));
+        CacheProperties propertiesCache = MAPPER.readValue(json, CacheProperties.class);
+        _verifySizeTwoAndContains(propertiesCache.cache.asMap());
+
+        // Delegating
+        String delegatingJson = MAPPER.writeValueAsString(new CacheDelegating(cache));
+        CacheDelegating delegtingCache = MAPPER.readValue(delegatingJson, CacheDelegating.class);
+        _verifySizeTwoAndContains(delegtingCache.cache.asMap());
+    }
+
+    // [datatype-collections#96]
+    private void _verifySizeTwoAndContains(Map<Long, Integer> map) {
+        assertEquals(2, map.size());
+        assertEquals(1, map.get(1L).intValue());
+        assertEquals(2, map.get(2L).intValue());
+    }
+
+    public void testEnumKey() throws Exception {
+        final TypeReference<Cache<MyEnum, Integer>> type = new TypeReference<Cache<MyEnum, Integer>>() {};
+        final Cache<MyEnum, Integer> cache = CacheBuilder.newBuilder().build();
+
+        cache.put(MyEnum.YAY, 5);
+        cache.put(MyEnum.BOO, 2);
+
+        final String serializedForm = MAPPER.writerFor(type).writeValueAsString(cache);
+
+        assertEquals(serializedForm, MAPPER.writeValueAsString(cache));
+        assertEquals(cache, MAPPER.readValue(serializedForm, type));
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private static class CacheWrapper {
+        @JsonProperty
+        private Cache<String, String> cache = CacheBuilder.newBuilder().build();
+    }
+
+    public void testEmptyCacheExclusion() throws Exception {
+        String json = MAPPER.writeValueAsString(new CacheWrapper());
+        assertEquals("{}", json);
+    }
+
+    public void testWithGuavaOptional() throws Exception {
+        // set up
+        Cache<String, Optional<Double>> cache = CacheBuilder.newBuilder().build();
+        cache.put("a", Optional.of(6.0));
+        cache.put("b", Optional.absent());
+
+        // test ser
+        String jsonStr = MAPPER.writeValueAsString(cache);
+        assertEquals(a2q("{'a':6.0,'b':null}"), jsonStr);
+
+        // test deser
+        Cache<String, Optional<Double>> deserializedCache = MAPPER.readValue(jsonStr,
+            new TypeReference<Cache<String, Optional<Double>>>() {});
+
+        // test before and after
+        assertEquals(cache.asMap().entrySet(), deserializedCache.asMap().entrySet());
+    }
+}


### PR DESCRIPTION
Supports deserialization side of `Cache` following #112. 

### Notes

1. Implementation and class detection is can be kept miminal because Guava's `Cache` itself heavily relies on builder mechanism through `CacheBuilder` so it is most likely we cannot initialize by its subclasses. 
2. Here we referenced most from [`GuavaMultimapDeserializer`](https://github.com/FasterXML/jackson-datatypes-collections/blob/2.16/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/multimap/GuavaMultimapDeserializer.java) Like how #112 Cache serialization was implemented.
