### PR TITLE
Backport `RangeSetDeserializer` from 3.0

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeSetDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeSetDeserializer.java
@@ -24,7 +24,6 @@ import com.google.common.collect.RangeSet;
  * <ul>
  *     <li>class declaration</li>
  *     <li>JsonDeserializer in 2.x -> ValueDeserializer in 3.0</li>
- *     <li>(WIP <a href="https://github.com/FasterXML/jackson-datatypes-collections/pull/120/files#r1219010881">discussion link</a>) _findType implementation</li>
  * </ul>
  * 
  * @since 2.16 


### PR DESCRIPTION
follow up of https://github.com/FasterXML/jackson-datatypes-collections/pull/119#issuecomment-1575222106.

### Motivation

To remove unstable `RangeSetDeserializer` implementaton, backport RangeSetDeserializer from 3.0.

### Prerequisite

 Backport `TypeFactory.findFirstTypeParameter()` from Jackson 3.0 https://github.com/FasterXML/jackson-databind/pull/3966, the only missing part in 2.16.