### PR TITLE
Add a test method for #118

### DIFF
--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestRange.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/TestRange.java
@@ -1,7 +1,10 @@
 package com.fasterxml.jackson.datatype.guava;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -38,6 +41,23 @@ public class TestRange extends ModuleTestBase
 
         public Wrapped() { }
         public Wrapped(Range<Integer> r) { this.r = r; }
+    }
+
+    static class Stringified<T extends Comparable> {
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Range<T> r;
+
+        public Stringified() {
+        }
+
+        public Stringified(Range<T> r) {
+            this.r = r;
+        }
+
+        public Range<T> toRange() {
+            return r;
+        }
     }
     
     /**
@@ -315,5 +335,44 @@ public class TestRange extends ModuleTestBase
 
         assertEquals(BoundType.CLOSED, result.lowerBoundType());
         assertEquals(BoundType.CLOSED, result.upperBoundType());
+    }
+
+    public void testSerializationToString() throws Exception
+    {
+        // Test open range serialization
+        Range<Integer> openRange = RangeFactory.open(1, 10);
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(openRange)), "{\"r\":\"(1..10)\"}");
+
+        // Test closed range serialization
+        Range<Integer> closedRange = RangeFactory.closed(5, 15);
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(closedRange)), "{\"r\":\"[5..15]\"}");
+
+        // Test open-closed range serialization
+        Range<Integer> openClosedRange = RangeFactory.openClosed(10, 20);
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(openClosedRange)), "{\"r\":\"(10..20]\"}");
+
+        // Test closed-open range serialization
+        Range<Integer> closedOpenRange = RangeFactory.closedOpen(25, 30);
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(closedOpenRange)), "{\"r\":\"[25..30)\"}");
+
+        // Test single point range serialization
+        Range<Integer> singletonRange = RangeFactory.singleton(42);
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(singletonRange)), "{\"r\":\"[42..42]\"}");
+
+        // Test unbounded range serialization
+        Range<Integer> unboundedRange = RangeFactory.all();
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(unboundedRange)), "{\"r\":\"(-∞..+∞)\"}");
+
+        // Test open range serialization with Duration
+        Range<Duration> openDurationRange = RangeFactory.open(Duration.ofMinutes(30), Duration.ofMinutes(60));
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(openDurationRange)), "{\"r\":\"(PT30M..PT1H)\"}");
+
+        // Test closed range serialization with LocalDate
+        Range<LocalDate> closedDateRange = RangeFactory.closed(LocalDate.parse("2023-01-01"), LocalDate.parse("2023-01-31"));
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(closedDateRange)), "{\"r\":\"[2023-01-01..2023-01-31]\"}");
+
+        // Test open-closed range serialization with String
+        Range<String> openClosedStringRange = RangeFactory.openClosed("abc", "def");
+        assertEquals(MAPPER.writeValueAsString(new Stringified<>(openClosedStringRange)), "{\"r\":\"(abc..def]\"}");
     }
 }


### PR DESCRIPTION
This commit introduces an initial version of the `testSerializationToString` method, designed to test the functionality expected by #118. The test cases are expected to fail as the underlying functionality has not been implemented. However, this provides a solid foundation to build upon and a starting point for implementing the desired functionality.

Building on @saydar31's progress, I will soon be creating a PR for the serialization of Range.
