### PR TITLE
Add support for ImmutableIntArray / ImmutableDoubleArray

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.datatype.guava;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
+import com.fasterxml.jackson.datatype.guava.ser.ImmutableDoubleArraySerializer;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.collect.*;
@@ -21,6 +23,8 @@ import com.fasterxml.jackson.datatype.guava.deser.multimap.list.ArrayListMultima
 import com.fasterxml.jackson.datatype.guava.deser.multimap.list.LinkedListMultimapDeserializer;
 import com.fasterxml.jackson.datatype.guava.deser.multimap.set.HashMultimapDeserializer;
 import com.fasterxml.jackson.datatype.guava.deser.multimap.set.LinkedHashMultimapDeserializer;
+import com.google.common.primitives.ImmutableDoubleArray;
+import com.google.common.primitives.ImmutableIntArray;
 
 /**
  * Custom deserializers module offers.
@@ -129,7 +133,6 @@ public class GuavaDeserializers
                     elementDeserializer, elementTypeDeserializer,
                     null, null);
         }
-
         return null;
     }
 
@@ -330,6 +333,12 @@ public class GuavaDeserializers
         if (type.hasRawClass(HashCode.class)) {
             return HashCodeDeserializer.std;
         }
+        if (type.hasRawClass(ImmutableIntArray.class)) {
+            return new ImmutableIntArrayDeserializer();
+        }
+        if (type.hasRawClass(ImmutableDoubleArray.class)) {
+            return new ImmutableDoubleArrayDeserializer();
+        }
         return null;
     }
 
@@ -348,6 +357,8 @@ public class GuavaDeserializers
                     || ImmutableMap.class.isAssignableFrom(valueType)
                     || BiMap.class.isAssignableFrom(valueType)
                     || ImmutableRangeSet.class.isAssignableFrom(valueType)
+                    || (valueType == ImmutableIntArray.class)
+                    || (valueType == ImmutableDoubleArray.class)
                     ;
         }
         return false;

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.type.MapLikeType;
 import com.fasterxml.jackson.databind.type.ReferenceType;
 import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer;
 import com.fasterxml.jackson.databind.util.StdConverter;
-import com.fasterxml.jackson.datatype.guava.ser.RangeSetSerializer;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -26,10 +25,15 @@ import com.google.common.collect.Table;
 import com.google.common.hash.HashCode;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.InternetDomainName;
+import com.google.common.primitives.ImmutableDoubleArray;
+import com.google.common.primitives.ImmutableIntArray;
 import com.fasterxml.jackson.datatype.guava.ser.CacheSerializer;
 import com.fasterxml.jackson.datatype.guava.ser.GuavaOptionalSerializer;
+import com.fasterxml.jackson.datatype.guava.ser.ImmutableDoubleArraySerializer;
+import com.fasterxml.jackson.datatype.guava.ser.ImmutableIntArraySerializer;
 import com.fasterxml.jackson.datatype.guava.ser.MultimapSerializer;
 import com.fasterxml.jackson.datatype.guava.ser.RangeSerializer;
+import com.fasterxml.jackson.datatype.guava.ser.RangeSetSerializer;
 import com.fasterxml.jackson.datatype.guava.ser.TableSerializer;
 
 public class GuavaSerializers extends Serializers.Base
@@ -92,6 +96,12 @@ public class GuavaSerializers extends Serializers.Base
         if (FluentIterable.class.isAssignableFrom(raw)) {
             JavaType iterableType = _findDeclared(type, Iterable.class);
             return new StdDelegatingSerializer(FluentConverter.instance, iterableType, null);
+        }
+        if (ImmutableIntArray.class.isAssignableFrom(raw)) {
+            return new ImmutableIntArraySerializer();
+        }
+        if (ImmutableDoubleArray.class.isAssignableFrom(raw)) {
+            return new ImmutableDoubleArraySerializer();
         }
         return super.findSerializer(config, type, beanDesc);
     }

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/ImmutableDoubleArrayDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/ImmutableDoubleArrayDeserializer.java
@@ -1,0 +1,50 @@
+package com.fasterxml.jackson.datatype.guava.deser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.util.AccessPattern;
+import com.google.common.primitives.ImmutableDoubleArray;
+
+import java.io.IOException;
+
+public final class ImmutableDoubleArrayDeserializer extends StdDeserializer<ImmutableDoubleArray> {
+
+    private final JsonDeserializer<double[]> doubleArrayDeserializer;
+
+    public ImmutableDoubleArrayDeserializer() {
+        super(ImmutableDoubleArray.class);
+        @SuppressWarnings("unchecked")
+        JsonDeserializer<double[]> doubleArrayDeserializer = (JsonDeserializer<double[]>) PrimitiveArrayDeserializers.forType(double.class);
+        this.doubleArrayDeserializer = doubleArrayDeserializer;
+    }
+
+    @Override
+    public Boolean supportsUpdate(DeserializationConfig config) {
+        return Boolean.FALSE;
+    }
+
+    @Override
+    public boolean isCachable() {
+        return true;
+    }
+
+    @Override
+    public AccessPattern getEmptyAccessPattern() {
+        return AccessPattern.CONSTANT;
+    }
+
+    @Override
+    public ImmutableDoubleArray getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
+        return ImmutableDoubleArray.of();
+    }
+
+    @Override
+    public ImmutableDoubleArray deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        return ImmutableDoubleArray.copyOf(doubleArrayDeserializer.deserialize(jsonParser, deserializationContext));
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/ImmutableIntArrayDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/ImmutableIntArrayDeserializer.java
@@ -1,0 +1,50 @@
+package com.fasterxml.jackson.datatype.guava.deser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.util.AccessPattern;
+import com.google.common.primitives.ImmutableIntArray;
+
+import java.io.IOException;
+
+public final class ImmutableIntArrayDeserializer extends StdDeserializer<ImmutableIntArray> {
+
+    private final JsonDeserializer<int[]> intArrayDeserializer;
+
+    public ImmutableIntArrayDeserializer() {
+        super(ImmutableIntArray.class);
+        @SuppressWarnings("unchecked")
+        JsonDeserializer<int[]> intArrayDeserializer = (JsonDeserializer<int[]>) PrimitiveArrayDeserializers.forType(int.class);
+        this.intArrayDeserializer = intArrayDeserializer;
+    }
+
+    @Override
+    public Boolean supportsUpdate(DeserializationConfig config) {
+        return Boolean.FALSE;
+    }
+
+    @Override
+    public boolean isCachable() {
+        return true;
+    }
+
+    @Override
+    public AccessPattern getEmptyAccessPattern() {
+        return AccessPattern.CONSTANT;
+    }
+
+    @Override
+    public ImmutableIntArray getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
+        return ImmutableIntArray.of();
+    }
+
+    @Override
+    public ImmutableIntArray deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        return ImmutableIntArray.copyOf(intArrayDeserializer.deserialize(jsonParser, deserializationContext));
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/ImmutableDoubleArraySerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/ImmutableDoubleArraySerializer.java
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.datatype.guava.ser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.primitives.ImmutableDoubleArray;
+
+import java.io.IOException;
+
+public final class ImmutableDoubleArraySerializer extends StdSerializer<ImmutableDoubleArray> {
+
+    public ImmutableDoubleArraySerializer() {
+        super(ImmutableDoubleArray.class);
+    }
+
+    @Override
+    public boolean isEmpty(SerializerProvider provider, ImmutableDoubleArray value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public void serialize(ImmutableDoubleArray value, JsonGenerator generator, SerializerProvider serializerProvider) throws IOException {
+        generator.writeStartArray();
+        for (int i = 0; i < value.length(); i++) {
+            generator.writeNumber(value.get(i));
+        }
+        generator.writeEndArray();
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/ImmutableIntArraySerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/ImmutableIntArraySerializer.java
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.datatype.guava.ser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.primitives.ImmutableIntArray;
+
+import java.io.IOException;
+
+public final class ImmutableIntArraySerializer extends StdSerializer<ImmutableIntArray> {
+
+    public ImmutableIntArraySerializer() {
+        super(ImmutableIntArray.class);
+    }
+
+    @Override
+    public boolean isEmpty(SerializerProvider provider, ImmutableIntArray value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public void serialize(ImmutableIntArray value, JsonGenerator generator, SerializerProvider serializerProvider) throws IOException {
+        generator.writeStartArray();
+        for (int i = 0; i < value.length(); i++) {
+            generator.writeNumber(value.get(i));
+        }
+        generator.writeEndArray();
+    }
+}

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/ImmutableDoubleArrayTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/ImmutableDoubleArrayTest.java
@@ -1,0 +1,23 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.ImmutableDoubleArray;
+
+import java.io.IOException;
+
+public class ImmutableDoubleArrayTest extends ModuleTestBase {
+
+    private final ObjectMapper MAPPER = mapperWithModule();
+
+    public void testSerialization() throws IOException {
+        assertEquals("[]", MAPPER.writeValueAsString(ImmutableDoubleArray.of()));
+        assertEquals("[-1.0,0.0,1.0,2.0,3.1]", MAPPER.writeValueAsString(ImmutableDoubleArray.of(-1, 0, 1, 2, 3.1)));
+    }
+
+    public void testDeserialization() throws IOException {
+        assertEquals(ImmutableDoubleArray.of(), MAPPER.readValue("[]", ImmutableDoubleArray.class));
+        assertEquals(ImmutableDoubleArray.of(1, 2, 3), MAPPER.readValue("[1, 2, 3]", ImmutableDoubleArray.class));
+        assertEquals(ImmutableDoubleArray.of(1.1, 2.1, 3.1), MAPPER.readValue("[1.1, 2.1, 3.1]", ImmutableDoubleArray.class));
+        assertEquals(ImmutableDoubleArray.of(0.0, 1234.1, -500), MAPPER.readValue("[null, \"1234.1\", -500]", ImmutableDoubleArray.class));
+    }
+}

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/ImmutableIntArrayTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/ImmutableIntArrayTest.java
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.ImmutableIntArray;
+
+import java.io.IOException;
+
+public class ImmutableIntArrayTest extends ModuleTestBase {
+
+    private final ObjectMapper MAPPER = mapperWithModule();
+
+    public void testSerialization() throws IOException {
+        assertEquals("[]", MAPPER.writeValueAsString(ImmutableIntArray.of()));
+        assertEquals("[-1,0,1,2,3]", MAPPER.writeValueAsString(ImmutableIntArray.of(-1, 0, 1, 2, 3)));
+    }
+
+    public void testDeserialization() throws IOException {
+        assertEquals(ImmutableIntArray.of(), MAPPER.readValue("[]", ImmutableIntArray.class));
+        assertEquals(ImmutableIntArray.of(1, 2, 3), MAPPER.readValue("[1, 2, 3]", ImmutableIntArray.class));
+        assertEquals(ImmutableIntArray.of(0, 1234, -5), MAPPER.readValue("[null, \"1234\", -5]", ImmutableIntArray.class));
+    }
+}


### PR DESCRIPTION
Add serde support for ImmutableIntArray and ImmutableDoubleArray.

Note that for simplicity, the deserializers currently delegate to the implementations in PrimitiveArrayDeserializers, passing the deserialize primitive arrays to the respective `copyOf` factory methods. The benefit is that all of the various edge cases of reading ints / doubles is handled already in those implementations. The downside is that we make an extra copy of the array when we pass it to the `copyOf` method, but at least there is no waste in the array sizing in this case.