### PR TITLE
[JSTEP-10] migrate `hppc`, `eclipse-collections`, `pcollections` to JUnit 5

### DIFF
--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/DeserializerTest.java
@@ -167,21 +167,22 @@ import org.eclipse.collections.impl.factory.primitive.ShortLists;
 import org.eclipse.collections.impl.factory.primitive.ShortSets;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class DeserializerTest extends ModuleTestBase {
     private <T> void testCollection(T expected, String json, TypeReference<T> type) throws IOException {
         ObjectMapper objectMapper = mapperWithModule();
         T value = objectMapper.readValue(json, type);
-        Assert.assertEquals(expected, value);
-        Assert.assertTrue(objectMapper.getTypeFactory().constructType(type).getRawClass().isInstance(value));
+        assertEquals(expected, value);
+        assertTrue(objectMapper.getTypeFactory().constructType(type).getRawClass().isInstance(value));
     }
 
     private <T> void testCollection(T expected, String json, Class<T> type) throws IOException {
         T value = mapperWithModule().readValue(json, type);
-        Assert.assertEquals(expected, value);
-        Assert.assertTrue(type.isInstance(value));
+        assertEquals(expected, value);
+        assertTrue(type.isInstance(value));
     }
 
     @Test
@@ -465,7 +466,7 @@ public final class DeserializerTest extends ModuleTestBase {
                         .getMethod("ofAll", baseMapType)
                         .invoke(immutableFactory, mutableSample);
 
-                Assert.assertEquals(mutableSample, immutableSample);
+                assertEquals(mutableSample, immutableSample);
 
                 Function<Class<?>, JavaType> generify;
                 if (key == Object.class || value == Object.class) {
@@ -483,21 +484,21 @@ public final class DeserializerTest extends ModuleTestBase {
                             mapper.writerFor(generify.apply(baseMapType)).writeValueAsString(mutableSample);
                     String polyPrinted = mapper.writeValueAsString(mutableSample);
                     // compare trees so property order doesn't matter
-                    Assert.assertEquals(mapper.readTree(json), mapper.readTree(mutablePrinted));
-                    Assert.assertEquals(mapper.readTree(json), mapper.readTree(immutablePrinted));
-                    Assert.assertEquals(mapper.readTree(json), mapper.readTree(basePrinted));
-                    Assert.assertEquals(mapper.readTree(json), mapper.readTree(polyPrinted));
+                    assertEquals(mapper.readTree(json), mapper.readTree(mutablePrinted));
+                    assertEquals(mapper.readTree(json), mapper.readTree(immutablePrinted));
+                    assertEquals(mapper.readTree(json), mapper.readTree(basePrinted));
+                    assertEquals(mapper.readTree(json), mapper.readTree(polyPrinted));
                 } else {
                     Object mutableParsed = mapper.readValue(json, generify.apply(mutableMapType));
                     Object immutableParsed = mapper.readValue(json, generify.apply(immutableMapType));
                     Object baseParsed = mapper.readValue(json, generify.apply(baseMapType));
-                    Assert.assertEquals(mutableSample, mutableParsed);
-                    Assert.assertEquals(immutableSample, immutableParsed);
-                    Assert.assertEquals(mutableSample, baseParsed);
+                    assertEquals(mutableSample, mutableParsed);
+                    assertEquals(immutableSample, immutableParsed);
+                    assertEquals(mutableSample, baseParsed);
 
-                    Assert.assertTrue(mutableMapType.isInstance(mutableParsed));
-                    Assert.assertTrue(immutableMapType.isInstance(immutableParsed));
-                    Assert.assertTrue(baseMapType.isInstance(baseParsed));
+                    assertTrue(mutableMapType.isInstance(mutableParsed));
+                    assertTrue(immutableMapType.isInstance(immutableParsed));
+                    assertTrue(baseMapType.isInstance(baseParsed));
                 }
             }
         }
@@ -509,19 +510,19 @@ public final class DeserializerTest extends ModuleTestBase {
 
     @Test
     public void objectObjectMaps() throws IOException {
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().readValue("{\"abc\":\"def\"}", new TypeReference<MutableMap<String, String>>() {}),
                 Maps.mutable.of("abc", "def")
         );
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().readValue("{\"abc\":\"def\"}", new TypeReference<ImmutableMap<String, String>>() {}),
                 Maps.immutable.of("abc", "def")
         );
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().readValue("{\"abc\":\"def\"}", new TypeReference<MapIterable<String, String>>() {}),
                 Maps.mutable.of("abc", "def")
         );
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().readValue("{\"abc\":\"def\"}",
                                              new TypeReference<UnsortedMapIterable<String, String>>() {}),
                 Maps.mutable.of("abc", "def")
@@ -544,7 +545,7 @@ public final class DeserializerTest extends ModuleTestBase {
 
     @Test
     public void typeInfoObjectMap() throws IOException {
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule()
                         .readValue("{\"map\":{\"0\":{\"@c\":\".DeserializerTest$B\"}}}", Container.class).map,
                 IntObjectMaps.immutable.of(0, new B())
@@ -581,7 +582,7 @@ public final class DeserializerTest extends ModuleTestBase {
         // test case for jackson-datatypes-collections#71
         ImmutableMap<String, ImmutableList<A>> property =
                 Maps.immutable.of("foo", Lists.immutable.of(new B()));
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().readValue(
                         "{\"foo\": [{\"@c\": \".DeserializerTest$B\"}]}",
                         new TypeReference<ImmutableMap<String, ImmutableList<A>>>() {}),
@@ -594,7 +595,7 @@ public final class DeserializerTest extends ModuleTestBase {
         // auxiliary test case for jackson-datatypes-collections#71 - also worked before fix
         ImmutableMap<String, ImmutableMap<String, A>> property =
                 Maps.immutable.of("foo", Maps.immutable.of("bar", new B()));
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().readValue(
                         "{\"foo\": {\"bar\": {\"@c\": \".DeserializerTest$B\"}}}",
                         new TypeReference<ImmutableMap<String, ImmutableMap<String, A>>>() {}),
@@ -656,8 +657,8 @@ public final class DeserializerTest extends ModuleTestBase {
                                       + ",\"two\":" + mapperWithModule().writeValueAsString(sampleTwo) + "}";
                 Object samplePair = factory.invoke(null, sampleOne, sampleTwo);
 
-                Assert.assertEquals(expectedJson, mapperWithModule().writeValueAsString(samplePair));
-                Assert.assertEquals(samplePair, mapperWithModule().readValue(expectedJson, pairType));
+                assertEquals(expectedJson, mapperWithModule().writeValueAsString(samplePair));
+                assertEquals(samplePair, mapperWithModule().readValue(expectedJson, pairType));
             }
         }
     }
@@ -670,8 +671,8 @@ public final class DeserializerTest extends ModuleTestBase {
         String expectedJson = "{\"one\":" + mapper.writeValueAsString(sampleOne)
                               + ",\"two\":" + mapper.writeValueAsString(sampleTwo) + "}";
         Twin<String> twin = Tuples.twin((String) sampleOne, (String) sampleTwo);
-        Assert.assertEquals(expectedJson, mapper.writeValueAsString(twin));
-        Assert.assertEquals(twin, mapper.readValue(expectedJson, new TypeReference<Twin<String>>() {}));
+        assertEquals(expectedJson, mapper.writeValueAsString(twin));
+        assertEquals(twin, mapper.readValue(expectedJson, new TypeReference<Twin<String>>() {}));
     }
 
     @Test
@@ -681,8 +682,8 @@ public final class DeserializerTest extends ModuleTestBase {
         final String actJson = mapper.writerFor(new TypeReference<ObjectIntPair<A>>() {})
                 .writeValueAsString(pair);
         String expJson = "{\"one\":{\"@c\":\".DeserializerTest$B\"},\"two\":5}";
-        Assert.assertEquals(mapper.readTree(expJson), mapper.readTree(actJson));
-        Assert.assertEquals(pair,
+        assertEquals(mapper.readTree(expJson), mapper.readTree(actJson));
+        assertEquals(pair,
                 mapper.readValue(actJson, new TypeReference<ObjectIntPair<A>>() {})
         );
     }
@@ -693,8 +694,8 @@ public final class DeserializerTest extends ModuleTestBase {
         String json = "{\"a\":{\"b\":\"c\"}}";
         TypeReference<MutableMap<String, MutableMap<String, String>>> type =
                 new TypeReference<MutableMap<String, MutableMap<String, String>>>() {};
-        Assert.assertEquals(json, mapperWithModule().writerFor(type).writeValueAsString(pair));
-        Assert.assertEquals(pair, mapperWithModule().readValue(json, type));
+        assertEquals(json, mapperWithModule().writerFor(type).writeValueAsString(pair));
+        assertEquals(pair, mapperWithModule().readValue(json, type));
     }
 
     @Test
@@ -704,8 +705,8 @@ public final class DeserializerTest extends ModuleTestBase {
         String actJson = mapper.writerFor(new TypeReference<Triple<String, Integer, Boolean>>() {})
                 .writeValueAsString(triple);
         String expJson = "{\"one\":\"a\",\"two\":2,\"three\":false}";
-        Assert.assertEquals(mapper.readTree(expJson), mapper.readTree(actJson));
-        Assert.assertEquals(
+        assertEquals(mapper.readTree(expJson), mapper.readTree(actJson));
+        assertEquals(
                 triple,
                 mapper.readValue(actJson, new TypeReference<Triple<String, Integer, Boolean>>() {})
         );
@@ -718,8 +719,8 @@ public final class DeserializerTest extends ModuleTestBase {
         String actJson = mapper.writerFor(new TypeReference<Triplet<String>>() {})
                 .writeValueAsString(triple);
         String expJson = "{\"one\":\"a\",\"two\":\"b\",\"three\":\"c\"}";
-        Assert.assertEquals(mapper.readTree(expJson), mapper.readTree(actJson));
-        Assert.assertEquals(
+        assertEquals(mapper.readTree(expJson), mapper.readTree(actJson));
+        assertEquals(
                 triple,
                 mapper.readValue(actJson, new TypeReference<Triplet<String>>() {})
         );

--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/Fuzz124_64629Test.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/Fuzz124_64629Test.java
@@ -1,14 +1,12 @@
 package com.fasterxml.jackson.datatype.eclipsecollections;
 
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import org.eclipse.collections.api.map.primitive.MutableCharCharMap;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for verifying the fixes for OSS-Fuzz issues
@@ -25,7 +23,7 @@ public class Fuzz124_64629Test extends ModuleTestBase
         // Invalid token {"x?":[x?]: where ? is not ascii characters
         final char[] invalid = {123, 34, 824, 34, 58, 91, 120, 7, 93};
 
-        MismatchedInputException e = Assert.assertThrows(
+        MismatchedInputException e = assertThrows(
             MismatchedInputException.class,
             () -> MAPPER.readValue(new String(invalid), MutableCharCharMap.class));
         assertTrue(e.getMessage().contains("Cannot convert a JSON Null into a char element of map"));

--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/ModuleTestBase.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/ModuleTestBase.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.datatype.eclipsecollections;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class ModuleTestBase {
 

--- a/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/SerializerTest.java
+++ b/eclipse-collections/src/test/java/com/fasterxml/jackson/datatype/eclipsecollections/SerializerTest.java
@@ -24,13 +24,15 @@ import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.factory.primitive.ShortLists;
-import org.junit.Assert;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class SerializerTest extends ModuleTestBase {
     @Test
     public void ref() throws IOException {
-        Assert.assertEquals(
+        assertEquals(
                 "[\"a\",\"b\",\"c\"]",
                 mapperWithModule().writeValueAsString(Sets.immutable.of("a", "b", "c"))
         );
@@ -38,26 +40,26 @@ public final class SerializerTest extends ModuleTestBase {
 
     @Test
     public void primitive() throws IOException {
-        Assert.assertEquals("[true,false,true]", mapperWithModule().writeValueAsString(
+        assertEquals("[true,false,true]", mapperWithModule().writeValueAsString(
                 BooleanLists.immutable.of(true, false, true)));
-        Assert.assertEquals("[1,2,3]", mapperWithModule().writeValueAsString(
+        assertEquals("[1,2,3]", mapperWithModule().writeValueAsString(
                 ShortLists.immutable.of((short) 1, (short) 2, (short) 3)));
-        Assert.assertEquals("[1,2,3]", mapperWithModule().writeValueAsString(
+        assertEquals("[1,2,3]", mapperWithModule().writeValueAsString(
                 IntLists.immutable.of(1, 2, 3)));
-        Assert.assertEquals("[1.1,2.3,3.5]", mapperWithModule().writeValueAsString(
+        assertEquals("[1.1,2.3,3.5]", mapperWithModule().writeValueAsString(
                 FloatLists.immutable.of(1.1F, 2.3F, 3.5F)));
-        Assert.assertEquals("[1,2,3]", mapperWithModule().writeValueAsString(
+        assertEquals("[1,2,3]", mapperWithModule().writeValueAsString(
                 LongLists.immutable.of(1, 2, 3)));
-        Assert.assertEquals("[1.1,2.3,3.5]", mapperWithModule().writeValueAsString(
+        assertEquals("[1.1,2.3,3.5]", mapperWithModule().writeValueAsString(
                 DoubleLists.immutable.of(1.1, 2.3, 3.5)));
 
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().writeValueAsString(new byte[]{ 1, 2, 3 }),
                 mapperWithModule().writeValueAsString(ByteLists.immutable.of((byte) 1, (byte) 2, (byte) 3)));
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().writeValueAsString(new char[]{ '1', '2', '3' }),
                 mapperWithModule().writeValueAsString(CharLists.immutable.of('1', '2', '3')));
-        Assert.assertEquals(
+        assertEquals(
                 mapperWithModule().configure(SerializationFeature.WRITE_CHAR_ARRAYS_AS_JSON_ARRAYS, true)
                         .writeValueAsString(new char[]{ '1', '2', '3' }),
                 mapperWithModule().configure(SerializationFeature.WRITE_CHAR_ARRAYS_AS_JSON_ARRAYS, true)
@@ -82,7 +84,7 @@ public final class SerializerTest extends ModuleTestBase {
         Wrapper wrapper = new Wrapper();
         wrapper.object = iterable;
 
-        Assert.assertEquals("{\"object\":[\"" + iterable.getClass().getName() + "\"," + data + "]}",
+        assertEquals("{\"object\":[\"" + iterable.getClass().getName() + "\"," + data + "]}",
                             objectMapper.writeValueAsString(wrapper));
     }
 
@@ -117,27 +119,27 @@ public final class SerializerTest extends ModuleTestBase {
 
     @Test
     public void objectObjectMaps() throws IOException {
-        Assert.assertEquals(
+        assertEquals(
                 "{\"abc\":\"def\"}",
                 mapperWithModule().writerFor(MutableMap.class).writeValueAsString(Maps.mutable.of("abc", "def"))
         );
-        Assert.assertEquals(
+        assertEquals(
                 "{\"abc\":\"def\"}",
                 mapperWithModule().writerFor(ImmutableMap.class).writeValueAsString(Maps.immutable.of("abc", "def"))
         );
-        Assert.assertEquals(
+        assertEquals(
                 "{\"abc\":\"def\"}",
                 mapperWithModule().writerFor(MapIterable.class).writeValueAsString(Maps.immutable.of("abc", "def"))
         );
-        Assert.assertEquals(
+        assertEquals(
                 "{\"abc\":\"def\"}",
                 mapperWithModule().writerFor(MutableMapIterable.class).writeValueAsString(Maps.mutable.of("abc", "def"))
         );
-        Assert.assertEquals(
+        assertEquals(
                 "{\"abc\":\"def\"}",
                 mapperWithModule().writeValueAsString(Maps.immutable.of("abc", "def"))
         );
-        Assert.assertEquals(
+        assertEquals(
                 "{\"abc\":\"def\"}",
                 mapperWithModule().writerFor(new TypeReference<MapIterable<String, String>>() {})
                         .writeValueAsString(Maps.immutable.of("abc", "def"))
@@ -146,7 +148,7 @@ public final class SerializerTest extends ModuleTestBase {
 
     @Test
     public void typeInfoObjectMap() throws IOException {
-        Assert.assertEquals(
+        assertEquals(
                 "{\"map\":{\"0\":{\"@c\":\".SerializerTest$B\"}}}",
                 mapperWithModule().writeValueAsString(new Container())
         );

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -66,6 +66,13 @@ com.google.common.*;version="${version.guava.osgi}",
       <artifactId>guava</artifactId>
       <version>${version.guava}</version>
     </dependency>
+
+    <!-- 2025-Jan-22 joohyukkim : temporarily isolate JUnit 4 here... -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/HppcTestBase.java
+++ b/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/HppcTestBase.java
@@ -4,7 +4,9 @@ import java.util.Arrays;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public abstract class HppcTestBase extends junit.framework.TestCase
+import static org.junit.jupiter.api.Assertions.fail;
+
+public abstract class HppcTestBase
 {
     protected HppcTestBase() { }
     

--- a/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/TestVersions.java
+++ b/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/TestVersions.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.datatype.hppc;
 
 import java.io.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class TestVersions extends HppcTestBase
 {
     public void testMapperVersions() throws IOException

--- a/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/deser/TestContainerDeserializers.java
+++ b/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/deser/TestContainerDeserializers.java
@@ -4,36 +4,40 @@ import java.util.Arrays;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.junit.Assert;
-
 import com.carrotsearch.hppc.*;
+
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.datatype.hppc.HppcTestBase;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class TestContainerDeserializers extends HppcTestBase
 {
+
+    @Test
     public void testIntDeserializers() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
 
         // first, direct
         IntArrayList array = mapper.readValue("[1,-3]", IntArrayList.class);
-        Assert.assertArrayEquals(new int[] { 1, -3 }, array.toArray());
+        assertArrayEquals(new int[] { 1, -3 }, array.toArray());
         IntHashSet set = mapper.readValue("[-1234,0]", IntHashSet.class);
 
         // 08-Apr-2014, tatu: Order indeterminate actually, has change between 0.4 and 0.5
         _assertSets(new int[] { -1234, 0 }, set.toArray());
 
         IntArrayDeque dq = mapper.readValue("[0,13]", IntArrayDeque.class);
-        Assert.assertArrayEquals(new int[] { -0, 13 }, dq.toArray());
+        assertArrayEquals(new int[] { -0, 13 }, dq.toArray());
 
         // then via abstract class defaulting
         IntIndexedContainer array2 = mapper.readValue("[1,-3]", IntIndexedContainer.class);
-        Assert.assertArrayEquals(new int[] { 1, -3 }, array2.toArray());
+        assertArrayEquals(new int[] { 1, -3 }, array2.toArray());
         IntSet set2 = mapper.readValue("[-1234,0]", IntSet.class);
         _assertSets(new int[] { -1234, 0 }, set2.toArray());
         IntDeque dq2 = mapper.readValue("[0,13]", IntDeque.class);
-        Assert.assertArrayEquals(new int[] { -0, 13 }, dq2.toArray());
+        assertArrayEquals(new int[] { -0, 13 }, dq2.toArray());
     }
 
     private void _assertSets(int[] exp, int[] actual)
@@ -46,6 +50,6 @@ public class TestContainerDeserializers extends HppcTestBase
         Arrays.sort(exp2);
         Arrays.sort(act2);
 
-        Assert.assertArrayEquals(exp2, act2);
+        assertArrayEquals(exp2, act2);
     }
 }

--- a/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/ser/TestContainerSerializers.java
+++ b/hppc/src/test/java/com/fasterxml/jackson/datatype/hppc/ser/TestContainerSerializers.java
@@ -3,11 +3,15 @@ package com.fasterxml.jackson.datatype.hppc.ser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.carrotsearch.hppc.*;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.datatype.hppc.HppcTestBase;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class TestContainerSerializers extends HppcTestBase
 {
+    @Test
     public void testByteSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -35,6 +39,7 @@ public class TestContainerSerializers extends HppcTestBase
         */
     }
 
+    @Test
     public void testShortSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -51,6 +56,7 @@ public class TestContainerSerializers extends HppcTestBase
         }
     }
 
+    @Test
     public void testIntSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -67,6 +73,7 @@ public class TestContainerSerializers extends HppcTestBase
         }
     }
 
+    @Test
     public void testLongSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -83,6 +90,7 @@ public class TestContainerSerializers extends HppcTestBase
         }
     }
 
+    @Test
     public void testCharSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -99,6 +107,7 @@ public class TestContainerSerializers extends HppcTestBase
         }
     }
 
+    @Test
     public void testFloatSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -117,6 +126,7 @@ public class TestContainerSerializers extends HppcTestBase
         */
     }
 
+    @Test
     public void testDoubleSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -141,6 +151,7 @@ public class TestContainerSerializers extends HppcTestBase
     /**********************************************************************
      */
 
+    @Test
     public void testObjectContainerSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();
@@ -153,7 +164,8 @@ public class TestContainerSerializers extends HppcTestBase
 
         // TODO: polymorphic case (@JsonTypeInfo and/or default typing)
     }
-    
+
+    @Test
     public void testBitSetSerializer() throws Exception
     {
         ObjectMapper mapper = mapperWithModule();

--- a/pcollections/src/test/java/com/fasterxml/jackson/datatype/pcollections/ModuleTestBase.java
+++ b/pcollections/src/test/java/com/fasterxml/jackson/datatype/pcollections/ModuleTestBase.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class ModuleTestBase {
 

--- a/pcollections/src/test/java/com/fasterxml/jackson/datatype/pcollections/TestPCollections.java
+++ b/pcollections/src/test/java/com/fasterxml/jackson/datatype/pcollections/TestPCollections.java
@@ -9,10 +9,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 
-import org.junit.Test;
 import org.pcollections.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for verifying that various PCollection types

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,15 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
-    <!-- 20-Apr-2024, tatu: JUnit4 no longer from jackson-base, so: -->
+    <!-- Use JUnit 5 -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -88,11 +93,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <excludes>
-              <exclude>com/fasterxml/jackson/**/failing/*.java</exclude>
-            </excludes>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
part of #174
These modules are small enough to bundle up in one PR.
`guava` module will follow.