### PR TITLE
Fix #158: mark min Guava tested as 22.0 (from 20.0) for 2.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,9 @@ permissions:
 
 env:
   GUAVA_DEFAULT: '25.1-jre'
-  GUAVA_MIN: '20.0'
-  GUAVA_MAX: '33.1.0-jre'
+  # 17-Jul-2025, tatu: Raised min from 20 to 22 in Jackson 2.20
+  GUAVA_MIN: '22.0'
+  GUAVA_MAX: '33.4.8-jre'
 jobs:
   build:
     runs-on: 'ubuntu-24.04'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use these format backends Maven-based projects, use following dependency:
 <dependency>
   <groupId>com.fasterxml.jackson.datatype</groupId>
   <artifactId>jackson-datatype-[COLLECTION]</artifactId>
-  <version>2.13.3</version>
+  <version>2.19.1</version>
 </dependency>
 ```
 

--- a/guava/README.md
+++ b/guava/README.md
@@ -12,7 +12,7 @@ To use module on Maven-based projects, use following dependency:
 <dependency>
   <groupId>com.fasterxml.jackson.datatype</groupId>
   <artifactId>jackson-datatype-guava</artifactId>
-  <version>2.17.0</version>
+  <version>2.19.1</version>
 </dependency>
 ```
 
@@ -28,6 +28,8 @@ Following table shows the tested working ranges for recent module versions.
 
 | Module version | Min Guava | Default Guava | Max Guava |
 | -------------- | --------- | ------------- | --------- |
+| 2.20           | 22.0      | 25.1-jre      | 33.4.8-jre|
+| 2.19           | 20.0      | 25.1-jre      | 33.1.0-jre|
 | 2.18           | 20.0      | 25.1-jre      | 33.1.0-jre|
 | 2.17           | 20.0      | 25.1-jre      | 33.1.0-jre|
 | 2.16           | 20.0      | 25.1-jre      | 33.1.0-jre|
@@ -41,7 +43,7 @@ Following table shows the tested working ranges for recent module versions.
 
 Notes:
 
-* At the point of testing, `31.1-jre` was the latest available Guava library
+* At the point of testing of 2.14 - 2.19,, `31.1-jre` was the latest available Guava library
 version, so all versions work with the latest Guava
 * "Min Guava" means the earliest version that integration tests pass with
 * "Default Guava" is the dependency specified in module's `pom.xml`: it is used for build, unit tests


### PR DESCRIPTION
Implements #158.