### PR TITLE
Add support for Guava RangeMap class [DRAFT]

### DIFF
--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -261,6 +261,11 @@ public class GuavaDeserializers
                     elementTypeDeserializer, elementDeserializer);
         }
 
+        if (RangeMap.class.isAssignableFrom(raw)) {
+            return new RangeMapDeserializer(type, keyDeserializer,
+                    elementTypeDeserializer, elementDeserializer, ImmutableRangeMap.class.isAssignableFrom(raw));
+        }
+
         if (Table.class.isAssignableFrom(raw)) {
             if (HashBasedTable.class.isAssignableFrom(raw)) {
                 return new HashBasedTableDeserializer(type);

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaKeyDeserializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaKeyDeserializers.java
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.KeyDeserializers;
+import com.fasterxml.jackson.datatype.guava.deser.RangeKeyDeserializer;
+import com.google.common.collect.Range;
+
+import java.io.Serializable;
+
+public class GuavaKeyDeserializers
+        implements Serializable,
+        KeyDeserializers {
+    static final long serialVersionUID = 1L;
+
+    @Override
+    public KeyDeserializer findKeyDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) throws JsonMappingException {
+        if (type.isTypeOrSubTypeOf(Range.class)) {
+            return new RangeKeyDeserializer(type);
+        }
+        return null;
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.guava;
 import com.fasterxml.jackson.core.Version;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.guava.deser.RangeKeyDeserializer;
 import com.fasterxml.jackson.datatype.guava.ser.GuavaBeanSerializerModifier;
 import com.google.common.collect.BoundType;
 
@@ -53,6 +54,7 @@ public class GuavaModule extends com.fasterxml.jackson.databind.Module // can't 
     public void setupModule(SetupContext context)
     {
         context.addDeserializers(new GuavaDeserializers(_defaultBoundType));
+        context.addKeyDeserializers(new GuavaKeyDeserializers());
         context.addSerializers(new GuavaSerializers());
         context.addTypeModifier(new GuavaTypeModifier());
 

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.datatype.guava;
 
+import com.fasterxml.jackson.datatype.guava.ser.RangeMapSerializer;
+import com.google.common.collect.RangeMap;
 import java.io.Serializable;
 import java.util.Set;
 
@@ -104,6 +106,15 @@ public class GuavaSerializers extends Serializers.Base
                     beanDesc.getClassInfo());
             Set<String> ignored = (ignorals == null) ? null : ignorals.getIgnored();
             return new MultimapSerializer(type, beanDesc,
+                    keySerializer, elementTypeSerializer, elementValueSerializer, ignored, filterId);
+        }
+        if (type.isTypeOrSubTypeOf(RangeMap.class)) {
+            final AnnotationIntrospector intr = config.getAnnotationIntrospector();
+            Object filterId = intr.findFilterId(beanDesc.getClassInfo());
+            JsonIgnoreProperties.Value ignorals = config.getDefaultPropertyIgnorals(RangeMap.class,
+                    beanDesc.getClassInfo());
+            Set<String> ignored = (ignorals == null) ? null : ignorals.getIgnored();
+            return new RangeMapSerializer(type, beanDesc,
                     keySerializer, elementTypeSerializer, elementValueSerializer, ignored, filterId);
         }
         if (type.isTypeOrSubTypeOf(Cache.class)) {

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaTypeModifier.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaTypeModifier.java
@@ -45,6 +45,11 @@ public class GuavaTypeModifier extends TypeModifier
                             type.containedTypeOrUnknown(0),
                             type.containedTypeOrUnknown(1));
         }
+        if (RangeMap.class.isAssignableFrom(raw)) {
+            return MapLikeType.upgradeFrom(type,
+                            typeFactory.constructParametricType(Range.class, type.containedTypeOrUnknown(0)),
+                            type.containedTypeOrUnknown(1));
+        }
         if (raw == Cache.class) {
             return MapLikeType.upgradeFrom(type,
                 type.containedTypeOrUnknown(0),

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeDeserializer.java
@@ -249,39 +249,7 @@ public class RangeDeserializer
             return null;
         }
 
-        if (isValidBracketNotation(rangeInterval)) {
-            BoundType lowerBoundType = rangeInterval.startsWith("[") ? BoundType.CLOSED : BoundType.OPEN;
-            BoundType upperBoundType = rangeInterval.endsWith("]") ? BoundType.CLOSED : BoundType.OPEN;
-
-            rangeInterval = rangeInterval.substring(1, rangeInterval.length() - 1);
-            String[] parts = PATTERN_DOUBLE_DOT.split(rangeInterval);
-
-            if (parts.length == 2) {
-                boolean isLowerInfinite = parts[0].equals("-∞");
-                boolean isUpperInfinite = parts[1].equals("+∞");
-
-                if (isLowerInfinite && isUpperInfinite) {
-                    return RangeFactory.all();
-                } else if (isLowerInfinite) {
-                    return RangeFactory.upTo(deserializeStringified(context, parts[1]), upperBoundType);
-                } else if (isUpperInfinite) {
-                    return RangeFactory.downTo(deserializeStringified(context, parts[0]), lowerBoundType);
-                } else {
-                    return RangeFactory.range(deserializeStringified(context, parts[0]),
-                            lowerBoundType,
-                            deserializeStringified(context, parts[1]),
-                            upperBoundType);
-                }
-            }
-        } else {
-            String msg = "Invalid Range: should start with '[' or '(', end with ')' or ']'";
-            return (Range<?>) context.handleWeirdStringValue(handledType(), rangeInterval, msg);
-        }
-
-        // Give generic failure if no specific reason can be given.
-        // Although most likely will happen because `..` is absent, since we are validating brackets above.
-        return (Range<?>) context.handleWeirdStringValue(handledType(), rangeInterval,
-                "Invalid bracket-notation representation (possibly missing \"..\" delimiter in your Stringified Range)");
+        return RangeHelper.getRangeFromString(rangeInterval, context, _fromStringDeserializer, _rangeType, handledType());
     }
 
     private BoundType deserializeBoundType(DeserializationContext context, JsonParser p) throws IOException

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeKeyDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeKeyDeserializer.java
@@ -1,0 +1,132 @@
+package com.fasterxml.jackson.datatype.guava.deser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualKeyDeserializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.datatype.guava.deser.util.RangeFactory;
+import com.fasterxml.jackson.datatype.guava.deser.util.RangeHelper;
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Jackson deserializer for a Guava {@link Range}.
+ * <p>
+ * TODO: I think it would make sense to reimplement this deserializer to
+ * use Delegating Deserializer, using a POJO as an intermediate form (properties
+ * could be of type {@link Object})
+ * This would also also simplify the implementation a bit.
+ */
+public class RangeKeyDeserializer
+        extends KeyDeserializer
+        implements ContextualKeyDeserializer {
+    private static final long serialVersionUID = 1L;
+
+    protected final static Pattern PATTERN_DOUBLE_DOT = Pattern.compile("\\.\\.");
+
+    protected final JavaType _rangeType;
+
+    protected final KeyDeserializer _fromStringDeserializer;
+
+    public RangeKeyDeserializer(JavaType type) {
+        this(type, null);
+    }
+
+    /**
+     * @since 2.17
+     */
+    @SuppressWarnings("unchecked")
+    protected RangeKeyDeserializer(JavaType rangeType, KeyDeserializer rangeDeserializer) {
+        _rangeType = rangeType;
+        _fromStringDeserializer = rangeDeserializer;
+    }
+
+    @Override
+    public KeyDeserializer createContextual(DeserializationContext ctxt,
+                                            BeanProperty property) throws JsonMappingException {
+        JavaType endpointType = _rangeType.containedType(0);
+        if (endpointType == null) { // should this ever occur?
+            endpointType = TypeFactory.unknownType();
+        }
+        KeyDeserializer kd = _fromStringDeserializer;
+            kd = ctxt.findKeyDeserializer(endpointType, property);
+        if ((kd != _fromStringDeserializer)) {
+            return new RangeKeyDeserializer(_rangeType, kd);
+        }
+        return this;
+    }
+
+    /*
+    /**********************************************************
+    /* Actual deserialization
+    /**********************************************************
+     */
+
+    @Override
+    public Object deserializeKey(String rangeInterval, DeserializationContext context) throws IOException {
+        if (rangeInterval.isEmpty()) {
+            return null;
+        }
+
+        if (isValidBracketNotation(rangeInterval)) {
+            BoundType lowerBoundType = rangeInterval.startsWith("[") ? BoundType.CLOSED : BoundType.OPEN;
+            BoundType upperBoundType = rangeInterval.endsWith("]") ? BoundType.CLOSED : BoundType.OPEN;
+
+            rangeInterval = rangeInterval.substring(1, rangeInterval.length() - 1);
+            String[] parts = PATTERN_DOUBLE_DOT.split(rangeInterval);
+
+            if (parts.length == 2) {
+                boolean isLowerInfinite = parts[0].equals("-∞");
+                boolean isUpperInfinite = parts[1].equals("+∞");
+
+                if (isLowerInfinite && isUpperInfinite) {
+                    return RangeFactory.all();
+                } else if (isLowerInfinite) {
+                    return RangeFactory.upTo(deserializeStringified(context, parts[1]), upperBoundType);
+                } else if (isUpperInfinite) {
+                    return RangeFactory.downTo(deserializeStringified(context, parts[0]), lowerBoundType);
+                } else {
+                    return RangeFactory.range(deserializeStringified(context, parts[0]),
+                            lowerBoundType,
+                            deserializeStringified(context, parts[1]),
+                            upperBoundType);
+                }
+            }
+        } else {
+            String msg = "Invalid Range: should start with '[' or '(', end with ')' or ']'";
+            return (Range<?>) context.handleWeirdStringValue(Range.class, rangeInterval, msg);
+        }
+
+        // Give generic failure if no specific reason can be given.
+        // Although most likely will happen because `..` is absent, since we are validating brackets above.
+        return (Range<?>) context.handleWeirdStringValue(Range.class, rangeInterval,
+                "Invalid bracket-notation representation (possibly missing \"..\" delimiter in your Stringified Range)");
+    }
+
+    private Comparable<?> deserializeStringified(DeserializationContext context, String value) throws IOException {
+        Object obj = _fromStringDeserializer.deserializeKey(value, context);
+        if (!(obj instanceof Comparable)) {
+            // 02-Jan-2024, tatu: Not sure this is possible but let's double-check
+            context.reportBadDefinition(_rangeType,
+                    String.format(
+                            "Stringified endpoint '%s' deserialized to a %s, which does not implement `Comparable`",
+                            value,
+                            ClassUtil.classNameOf(obj)));
+        }
+        return (Comparable<?>) obj;
+    }
+
+
+    private boolean isValidBracketNotation(String range) {
+        char first = range.charAt(0);
+        char last = range.charAt(range.length() - 1);
+
+        return (first == '[' || first == '(') && (last == ']' || last == ')');
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeKeyDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeKeyDeserializer.java
@@ -1,47 +1,36 @@
 package com.fasterxml.jackson.datatype.guava.deser;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.ContextualKeyDeserializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.databind.util.ClassUtil;
-import com.fasterxml.jackson.datatype.guava.deser.util.RangeFactory;
 import com.fasterxml.jackson.datatype.guava.deser.util.RangeHelper;
-import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 /**
- * Jackson deserializer for a Guava {@link Range}.
- * <p>
- * TODO: I think it would make sense to reimplement this deserializer to
- * use Delegating Deserializer, using a POJO as an intermediate form (properties
- * could be of type {@link Object})
- * This would also also simplify the implementation a bit.
+ * Jackson key deserializer for a Guava {@link Range}.
+ *
+ * @author mcvayc
+ * @since 2.21
  */
 public class RangeKeyDeserializer
         extends KeyDeserializer
         implements ContextualKeyDeserializer {
     private static final long serialVersionUID = 1L;
 
-    protected final static Pattern PATTERN_DOUBLE_DOT = Pattern.compile("\\.\\.");
-
     protected final JavaType _rangeType;
 
     protected final KeyDeserializer _fromStringDeserializer;
 
+    /**
+     * @since 2.21
+     */
     public RangeKeyDeserializer(JavaType type) {
         this(type, null);
     }
 
-    /**
-     * @since 2.17
-     */
-    @SuppressWarnings("unchecked")
     protected RangeKeyDeserializer(JavaType rangeType, KeyDeserializer rangeDeserializer) {
         _rangeType = rangeType;
         _fromStringDeserializer = rangeDeserializer;
@@ -55,78 +44,20 @@ public class RangeKeyDeserializer
             endpointType = TypeFactory.unknownType();
         }
         KeyDeserializer kd = _fromStringDeserializer;
-            kd = ctxt.findKeyDeserializer(endpointType, property);
+        kd = ctxt.findKeyDeserializer(endpointType, property);
         if ((kd != _fromStringDeserializer)) {
             return new RangeKeyDeserializer(_rangeType, kd);
         }
         return this;
     }
 
-    /*
-    /**********************************************************
-    /* Actual deserialization
-    /**********************************************************
-     */
-
     @Override
     public Object deserializeKey(String rangeInterval, DeserializationContext context) throws IOException {
         if (rangeInterval.isEmpty()) {
-            return null;
+            throw context.instantiationException(RangeMap.class, "RangeMap keys can't be null or empty.");
         }
 
-        if (isValidBracketNotation(rangeInterval)) {
-            BoundType lowerBoundType = rangeInterval.startsWith("[") ? BoundType.CLOSED : BoundType.OPEN;
-            BoundType upperBoundType = rangeInterval.endsWith("]") ? BoundType.CLOSED : BoundType.OPEN;
-
-            rangeInterval = rangeInterval.substring(1, rangeInterval.length() - 1);
-            String[] parts = PATTERN_DOUBLE_DOT.split(rangeInterval);
-
-            if (parts.length == 2) {
-                boolean isLowerInfinite = parts[0].equals("-∞");
-                boolean isUpperInfinite = parts[1].equals("+∞");
-
-                if (isLowerInfinite && isUpperInfinite) {
-                    return RangeFactory.all();
-                } else if (isLowerInfinite) {
-                    return RangeFactory.upTo(deserializeStringified(context, parts[1]), upperBoundType);
-                } else if (isUpperInfinite) {
-                    return RangeFactory.downTo(deserializeStringified(context, parts[0]), lowerBoundType);
-                } else {
-                    return RangeFactory.range(deserializeStringified(context, parts[0]),
-                            lowerBoundType,
-                            deserializeStringified(context, parts[1]),
-                            upperBoundType);
-                }
-            }
-        } else {
-            String msg = "Invalid Range: should start with '[' or '(', end with ')' or ']'";
-            return (Range<?>) context.handleWeirdStringValue(Range.class, rangeInterval, msg);
-        }
-
-        // Give generic failure if no specific reason can be given.
-        // Although most likely will happen because `..` is absent, since we are validating brackets above.
-        return (Range<?>) context.handleWeirdStringValue(Range.class, rangeInterval,
-                "Invalid bracket-notation representation (possibly missing \"..\" delimiter in your Stringified Range)");
+        return RangeHelper.getRangeFromString(rangeInterval, context, _fromStringDeserializer, _rangeType, Range.class);
     }
 
-    private Comparable<?> deserializeStringified(DeserializationContext context, String value) throws IOException {
-        Object obj = _fromStringDeserializer.deserializeKey(value, context);
-        if (!(obj instanceof Comparable)) {
-            // 02-Jan-2024, tatu: Not sure this is possible but let's double-check
-            context.reportBadDefinition(_rangeType,
-                    String.format(
-                            "Stringified endpoint '%s' deserialized to a %s, which does not implement `Comparable`",
-                            value,
-                            ClassUtil.classNameOf(obj)));
-        }
-        return (Comparable<?>) obj;
-    }
-
-
-    private boolean isValidBracketNotation(String range) {
-        char first = range.charAt(0);
-        char last = range.charAt(range.length() - 1);
-
-        return (first == '[' || first == '(') && (last == ']' || last == ')');
-    }
 }

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeMapDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeMapDeserializer.java
@@ -18,7 +18,12 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 /**
- * @author mvolkhart
+ * Jackson deserializer for a Guava {@link RangeMap}.
+ * <p>
+ * Only string serializable ranges are supported at this time.
+ *
+ * @author mcvayc
+ * @since 2.21
  */
 public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
         extends StdDeserializer<T> implements ContextualDeserializer {
@@ -30,7 +35,6 @@ public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
     private final TypeDeserializer elementTypeDeserializer;
     private final JsonDeserializer<?> elementDeserializer;
 
-    // since 2.9.5: in 3.x demote to `ContainerDeserializerBase`
     private final NullValueProvider nullProvider;
     private final boolean isImmutable;
     private final boolean skipNullValues;
@@ -42,6 +46,9 @@ public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
      */
     private final Method creatorMethod;
 
+    /**
+     * @since 2.21
+     */
     public RangeMapDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
                                 TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer,
                                 boolean isImmutable
@@ -50,6 +57,9 @@ public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
                 findTransformer(type.getRawClass()), null, isImmutable);
     }
 
+    /**
+     * @since 2.21
+     */
     public RangeMapDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
                                 TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer,
                                 Method creatorMethod, NullValueProvider nvp, boolean isImmutable) {
@@ -78,8 +88,6 @@ public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
                 }
             } catch (NoSuchMethodException e) {
             }
-            // pass SecurityExceptions as-is:
-            // } catch (SecurityException e) { }
         }
 
         // If not working, possibly super types too (should we?)
@@ -91,14 +99,12 @@ public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
                 }
             } catch (NoSuchMethodException e) {
             }
-            // pass SecurityExceptions as-is:
-            // } catch (SecurityException e) { }
         }
 
         return null;
     }
 
-    @Override // since 2.12
+    @Override
     public LogicalType logicalType() {
         return LogicalType.Map;
     }
@@ -133,22 +139,10 @@ public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
 
     @Override
     public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-
-        //check if ACCEPT_SINGLE_VALUE_AS_ARRAY feature is enabled
-        if (ctxt.isEnabled(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)) {
-            return deserializeFromSingleValue(p, ctxt);
-        }
-        // if not deserialize the normal way
-        return deserializeContents(p, ctxt);
-    }
-
-    private T deserializeContents(JsonParser p, DeserializationContext ctxt)
-            throws IOException {
         RangeMap rangeMap = TreeRangeMap.create();
 
         JsonToken currToken = p.currentToken();
         if (currToken != JsonToken.FIELD_NAME) {
-            // 01-Mar-2023, tatu: [datatypes-collections#104] Handle empty Maps too
             if (currToken != JsonToken.END_OBJECT) {
                 expect(p, JsonToken.START_OBJECT);
                 currToken = p.nextToken();
@@ -187,62 +181,6 @@ public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
         } catch (IllegalAccessException e) {
             throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
         }
-    }
-
-    private T deserializeFromSingleValue(JsonParser p, DeserializationContext ctxt)
-            throws IOException {
-        RangeMap rangeMap = TreeRangeMap.create();
-
-        expect(p, JsonToken.START_OBJECT);
-
-        while (p.nextToken() != JsonToken.END_OBJECT) {
-            final Range<Comparable<?>> key = (Range<Comparable<?>>) keyDeserializer.deserializeKey(p.currentName(), ctxt);
-
-            p.nextToken();
-
-            // if there is an array, parse the array and add the elements
-            if (p.currentToken() == JsonToken.START_ARRAY) {
-
-                while (p.nextToken() != JsonToken.END_ARRAY) {
-                    // get the current token value
-                    final Object value = getCurrentTokenValue(p, ctxt);
-                    // add the token value to the map
-                    rangeMap.put(key, value);
-                }
-            }
-            // if the element is a String, then add it as a List
-            else {
-                // get the current token value
-                final Object value = getCurrentTokenValue(p, ctxt);
-                // add the single value
-                rangeMap.put(key, value);
-            }
-        }
-        if (creatorMethod == null) {
-            return (T) rangeMap;
-        }
-        try {
-            @SuppressWarnings("unchecked")
-            T map = (T) creatorMethod.invoke(null, rangeMap);
-            return map;
-        } catch (InvocationTargetException e) {
-            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
-        } catch (IllegalArgumentException e) {
-            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
-        } catch (IllegalAccessException e) {
-            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
-        }
-    }
-
-    private Object getCurrentTokenValue(JsonParser p, DeserializationContext ctxt)
-            throws IOException {
-        if (p.currentToken() == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        if (elementTypeDeserializer != null) {
-            return elementDeserializer.deserializeWithType(p, ctxt, elementTypeDeserializer);
-        }
-        return elementDeserializer.deserialize(p, ctxt);
     }
 
     private void expect(JsonParser p, JsonToken token) throws IOException {

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeMapDeserializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeMapDeserializer.java
@@ -1,0 +1,261 @@
+package com.fasterxml.jackson.datatype.guava.deser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.NullValueProvider;
+import com.fasterxml.jackson.databind.deser.impl.NullsConstantProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.type.LogicalType;
+import com.fasterxml.jackson.databind.type.MapLikeType;
+import com.google.common.collect.*;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * @author mvolkhart
+ */
+public class RangeMapDeserializer<T extends RangeMap<Comparable<?>, Object>>
+        extends StdDeserializer<T> implements ContextualDeserializer {
+    private static final long serialVersionUID = 1L;
+
+    private static final List<String> METHOD_NAMES = ImmutableList.of("copyOf", "create");
+    private final MapLikeType type;
+    private final KeyDeserializer keyDeserializer;
+    private final TypeDeserializer elementTypeDeserializer;
+    private final JsonDeserializer<?> elementDeserializer;
+
+    // since 2.9.5: in 3.x demote to `ContainerDeserializerBase`
+    private final NullValueProvider nullProvider;
+    private final boolean isImmutable;
+    private final boolean skipNullValues;
+
+    /**
+     * Since we have to use a method to transform from a known range-map type into actual one, we'll
+     * resolve method just once, use it. Note that if this is set to null, we can just construct a
+     * {@link TreeRangeMap} instance and be done with it.
+     */
+    private final Method creatorMethod;
+
+    public RangeMapDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
+                                TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer,
+                                boolean isImmutable
+    ) {
+        this(type, keyDeserializer, elementTypeDeserializer, elementDeserializer,
+                findTransformer(type.getRawClass()), null, isImmutable);
+    }
+
+    public RangeMapDeserializer(MapLikeType type, KeyDeserializer keyDeserializer,
+                                TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer,
+                                Method creatorMethod, NullValueProvider nvp, boolean isImmutable) {
+        super(type);
+        this.type = type;
+        this.keyDeserializer = keyDeserializer;
+        this.elementTypeDeserializer = elementTypeDeserializer;
+        this.elementDeserializer = elementDeserializer;
+        this.creatorMethod = creatorMethod;
+        this.nullProvider = nvp;
+        this.isImmutable = isImmutable;
+        skipNullValues = (nvp == null) ? false : NullsConstantProvider.isSkipper(nvp);
+    }
+
+    private static Method findTransformer(Class<?> rawType) {
+        if (rawType == TreeRangeMap.class) {
+            return null;
+        }
+
+        // First, check type itself for matching methods
+        for (String methodName : METHOD_NAMES) {
+            try {
+                Method m = rawType.getDeclaredMethod(methodName, RangeMap.class);
+                if (m != null) {
+                    return m;
+                }
+            } catch (NoSuchMethodException e) {
+            }
+            // pass SecurityExceptions as-is:
+            // } catch (SecurityException e) { }
+        }
+
+        // If not working, possibly super types too (should we?)
+        for (String methodName : METHOD_NAMES) {
+            try {
+                Method m = rawType.getMethod(methodName, RangeMap.class);
+                if (m != null) {
+                    return m;
+                }
+            } catch (NoSuchMethodException e) {
+            }
+            // pass SecurityExceptions as-is:
+            // } catch (SecurityException e) { }
+        }
+
+        return null;
+    }
+
+    @Override // since 2.12
+    public LogicalType logicalType() {
+        return LogicalType.Map;
+    }
+
+    /**
+     * We need to use this method to properly handle possible contextual variants of key and value
+     * deserializers, as well as type deserializers.
+     */
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
+                                                BeanProperty property) throws JsonMappingException {
+        KeyDeserializer kd = keyDeserializer;
+        if (kd == null) {
+            kd = ctxt.findKeyDeserializer(type.getKeyType(), property);
+        }
+        JsonDeserializer<?> valueDeser = elementDeserializer;
+        final JavaType vt = type.getContentType();
+        if (valueDeser == null) {
+            valueDeser = ctxt.findContextualValueDeserializer(vt, property);
+        } else { // if directly assigned, probably not yet contextual, so:
+            valueDeser = ctxt.handleSecondaryContextualization(valueDeser, property, vt);
+        }
+        // Type deserializer is slightly different; must be passed, but needs to become contextual:
+        TypeDeserializer vtd = elementTypeDeserializer;
+        if (vtd != null) {
+            vtd = vtd.forProperty(property);
+        }
+
+        return new RangeMapDeserializer<>(type, kd, vtd, valueDeser, creatorMethod,
+                findContentNullProvider(ctxt, property, valueDeser), isImmutable);
+    }
+
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+
+        //check if ACCEPT_SINGLE_VALUE_AS_ARRAY feature is enabled
+        if (ctxt.isEnabled(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)) {
+            return deserializeFromSingleValue(p, ctxt);
+        }
+        // if not deserialize the normal way
+        return deserializeContents(p, ctxt);
+    }
+
+    private T deserializeContents(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        RangeMap rangeMap = TreeRangeMap.create();
+
+        JsonToken currToken = p.currentToken();
+        if (currToken != JsonToken.FIELD_NAME) {
+            // 01-Mar-2023, tatu: [datatypes-collections#104] Handle empty Maps too
+            if (currToken != JsonToken.END_OBJECT) {
+                expect(p, JsonToken.START_OBJECT);
+                currToken = p.nextToken();
+            }
+        }
+
+        for (; currToken == JsonToken.FIELD_NAME; currToken = p.nextToken()) {
+            final Range<Comparable<?>> key = (Range<Comparable<?>>) keyDeserializer.deserializeKey(p.currentName(), ctxt);
+
+            p.nextToken();
+            final Object value;
+            if (p.currentToken() == JsonToken.VALUE_NULL) {
+                if (skipNullValues) {
+                    continue;
+                }
+                value = nullProvider.getNullValue(ctxt);
+            } else if (elementTypeDeserializer != null) {
+                value = elementDeserializer.deserializeWithType(p, ctxt, elementTypeDeserializer);
+            } else {
+                value = elementDeserializer.deserialize(p, ctxt);
+            }
+            rangeMap.put(key, value);
+        }
+
+        if (creatorMethod == null) {
+            return (T) rangeMap;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            T map = (T) creatorMethod.invoke(null, rangeMap);
+            return map;
+        } catch (InvocationTargetException e) {
+            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
+        } catch (IllegalArgumentException e) {
+            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
+        } catch (IllegalAccessException e) {
+            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
+        }
+    }
+
+    private T deserializeFromSingleValue(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        RangeMap rangeMap = TreeRangeMap.create();
+
+        expect(p, JsonToken.START_OBJECT);
+
+        while (p.nextToken() != JsonToken.END_OBJECT) {
+            final Range<Comparable<?>> key = (Range<Comparable<?>>) keyDeserializer.deserializeKey(p.currentName(), ctxt);
+
+            p.nextToken();
+
+            // if there is an array, parse the array and add the elements
+            if (p.currentToken() == JsonToken.START_ARRAY) {
+
+                while (p.nextToken() != JsonToken.END_ARRAY) {
+                    // get the current token value
+                    final Object value = getCurrentTokenValue(p, ctxt);
+                    // add the token value to the map
+                    rangeMap.put(key, value);
+                }
+            }
+            // if the element is a String, then add it as a List
+            else {
+                // get the current token value
+                final Object value = getCurrentTokenValue(p, ctxt);
+                // add the single value
+                rangeMap.put(key, value);
+            }
+        }
+        if (creatorMethod == null) {
+            return (T) rangeMap;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            T map = (T) creatorMethod.invoke(null, rangeMap);
+            return map;
+        } catch (InvocationTargetException e) {
+            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
+        } catch (IllegalArgumentException e) {
+            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
+        } catch (IllegalAccessException e) {
+            throw new JsonMappingException(p, "Could not map to " + type, _peel(e));
+        }
+    }
+
+    private Object getCurrentTokenValue(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        if (p.currentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        if (elementTypeDeserializer != null) {
+            return elementDeserializer.deserializeWithType(p, ctxt, elementTypeDeserializer);
+        }
+        return elementDeserializer.deserialize(p, ctxt);
+    }
+
+    private void expect(JsonParser p, JsonToken token) throws IOException {
+        if (p.currentToken() != token) {
+            throw new JsonMappingException(p, "Expecting " + token + " to start `RangeMap` value, found " + p.currentToken(),
+                    p.currentLocation());
+        }
+    }
+
+    private Throwable _peel(Throwable t) {
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
+    }
+}

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/util/RangeHelper.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/deser/util/RangeHelper.java
@@ -1,11 +1,19 @@
 package com.fasterxml.jackson.datatype.guava.deser.util;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
 
 /**
  * @since 2.10
@@ -54,6 +62,8 @@ public class RangeHelper
 
     private final static Field[] FIELDS = STD_NAMES.fields();
 
+    private final static Pattern PATTERN_DOUBLE_DOT = Pattern.compile("\\.\\.");
+
     public static RangeProperties standardNames() {
         return STD_NAMES;
     }
@@ -76,4 +86,62 @@ public class RangeHelper
         AnnotatedField af = new AnnotatedField(typeCtxt, field, null);
         return pns.nameForField(config, af, field.getName());
     }
+
+    public static Range<? extends Comparable> getRangeFromString(String rangeInterval, DeserializationContext context, KeyDeserializer fromStringDeserializer, JavaType rangeType, Class<?> targetClass) throws IOException {
+        if (isValidBracketNotation(rangeInterval)) {
+            BoundType lowerBoundType = rangeInterval.startsWith("[") ? BoundType.CLOSED : BoundType.OPEN;
+            BoundType upperBoundType = rangeInterval.endsWith("]") ? BoundType.CLOSED : BoundType.OPEN;
+
+            rangeInterval = rangeInterval.substring(1, rangeInterval.length() - 1);
+            String[] parts = PATTERN_DOUBLE_DOT.split(rangeInterval);
+
+            if (parts.length == 2) {
+                boolean isLowerInfinite = parts[0].equals("-∞");
+                boolean isUpperInfinite = parts[1].equals("+∞");
+
+                if (isLowerInfinite && isUpperInfinite) {
+                    return RangeFactory.all();
+                } else if (isLowerInfinite) {
+                    return RangeFactory.upTo(deserializeStringified(context, parts[1], fromStringDeserializer, rangeType), upperBoundType);
+                } else if (isUpperInfinite) {
+                    return RangeFactory.downTo(deserializeStringified(context, parts[0], fromStringDeserializer, rangeType), lowerBoundType);
+                } else {
+                    return RangeFactory.range(deserializeStringified(context, parts[0], fromStringDeserializer, rangeType),
+                            lowerBoundType,
+                            deserializeStringified(context, parts[1], fromStringDeserializer, rangeType),
+                            upperBoundType);
+                }
+            }
+        } else {
+            String msg = "Invalid Range: should start with '[' or '(', end with ')' or ']'";
+            return (Range<?>) context.handleWeirdStringValue(targetClass, rangeInterval, msg);
+        }
+
+        // Give generic failure if no specific reason can be given.
+        // Although most likely will happen because `..` is absent, since we are validating brackets above.
+        return (Range<?>) context.handleWeirdStringValue(targetClass, rangeInterval,
+                "Invalid bracket-notation representation (possibly missing \"..\" delimiter in your Stringified Range)");
+    }
+
+    private static Comparable<?> deserializeStringified(DeserializationContext context, String value, KeyDeserializer fromStringDeserializer, JavaType rangeType) throws IOException {
+        Object obj = fromStringDeserializer.deserializeKey(value, context);
+        if (!(obj instanceof Comparable)) {
+            // 02-Jan-2024, tatu: Not sure this is possible but let's double-check
+            context.reportBadDefinition(rangeType,
+                    String.format(
+                            "Stringified endpoint '%s' deserialized to a %s, which does not implement `Comparable`",
+                            value,
+                            ClassUtil.classNameOf(obj)));
+        }
+        return (Comparable<?>) obj;
+    }
+
+
+    private static boolean isValidBracketNotation(String range) {
+        char first = range.charAt(0);
+        char last = range.charAt(range.length() - 1);
+
+        return (first == '[' || first == '(') && (last == ']' || last == ')');
+    }
+
 }

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/RangeMapSerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/RangeMapSerializer.java
@@ -29,8 +29,11 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 /**
- * Serializer for Guava's {@link RangeMap} values. Output format encloses all
+ * Serializer for Guava's {@link RangeMap} values. Output format encloses
  * values in JSON Map.
+ *
+ * @author mcvayc
+ * @since 2.21
  */
 public class RangeMapSerializer
         extends ContainerSerializer<RangeMap<Comparable<?>, ?>>
@@ -45,34 +48,29 @@ public class RangeMapSerializer
 
     /**
      * Set of entries to omit during serialization, if any
-     *
-     * @since 2.5
      */
     protected final Set<String> _ignoredEntries;
 
     /**
      * If value type can not be statically determined, mapping from
      * runtime value types to serializers are stored in this object.
-     *
-     * @since 2.5
      */
     protected PropertySerializerMap _dynamicValueSerializers;
 
     /**
      * Id of the property filter to use, if any; null if none.
-     *
-     * @since 2.5
      */
     protected final Object _filterId;
 
     /**
      * Flag set if output is forced to be sorted by keys (usually due
      * to annotation).
-     *
-     * @since 2.15
      */
     protected final boolean _sortKeys;
 
+    /**
+     * @since 2.21
+     */
     public RangeMapSerializer(MapLikeType type, BeanDescription beanDesc,
                               JsonSerializer<Object> keySerializer, TypeSerializer vts, JsonSerializer<Object> valueSerializer,
                               Set<String> ignoredEntries, Object filterId) {
@@ -161,7 +159,7 @@ public class RangeMapSerializer
         if (valueSer == null) {
             valueSer = _valueSerializer;
         }
-        // [datatype-guava#124]: May have a content converter
+        // May have a content converter
         valueSer = findContextualConvertingSerializer(provider, property, valueSer);
         if (valueSer == null) {
             // One more thing -- if explicit content type is annotated,
@@ -204,8 +202,7 @@ public class RangeMapSerializer
             Boolean b = intr.findSerializationSortAlphabetically(propertyAcc);
             sortKeys = (b != null) && b.booleanValue();
         }
-        // 19-May-2016, tatu: Also check per-property format features, even if
-        //    this isn't yet used (as per [guava#7])
+        // Also check per-property format features, even if this isn't yet used (as per [guava#7])
         JsonFormat.Value format = findFormatOverrides(provider, property, handledType());
         if (format != null) {
             Boolean B = format.getFeature(JsonFormat.Feature.WRITE_SORTED_MAP_ENTRIES);
@@ -253,7 +250,7 @@ public class RangeMapSerializer
     public void serialize(RangeMap<Comparable<?>, ?> value, JsonGenerator gen, SerializerProvider provider)
             throws IOException {
         gen.writeStartObject();
-        // [databind#631]: Assign current value, to be accessible by custom serializers
+        // Assign current value, to be accessible by custom serializers
         gen.assignCurrentValue(value);
         if (!isEmpty(value)) {
             if (_sortKeys || provider.isEnabled(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)) {
@@ -294,7 +291,7 @@ public class RangeMapSerializer
         typeSer.writeTypeSuffix(gen, typeIdDef);
     }
 
-    private final void serializeFields(Map<Range<Comparable<?>>, ?> rmap, JsonGenerator
+    private void serializeFields(Map<Range<Comparable<?>>, ?> rmap, JsonGenerator
             gen, SerializerProvider provider)
             throws IOException {
         final Set<String> ignored = _ignoredEntries;
@@ -302,7 +299,7 @@ public class RangeMapSerializer
         for (Entry<Range<Comparable<?>>, ?> entry : rmap.entrySet()) {
             // First, serialize key
             Range<?> key = entry.getKey();
-            if ((ignored != null) && ignored.contains(key)) {
+            if ((ignored != null) && ignored.contains(key.toString())) {
                 continue;
             }
             if (key == null) {
@@ -333,7 +330,7 @@ public class RangeMapSerializer
         }
     }
 
-    private final void serializeFilteredFields(Map<Range<Comparable<?>>, ?> rmap, JsonGenerator gen, SerializerProvider provider)
+    private void serializeFilteredFields(Map<Range<Comparable<?>>, ?> rmap, JsonGenerator gen, SerializerProvider provider)
             throws IOException {
         final Set<String> ignored = _ignoredEntries;
         PropertyFilter filter = findPropertyFilter(provider, _filterId, rmap);
@@ -368,6 +365,9 @@ public class RangeMapSerializer
     /**********************************************************
      */
 
+    /**
+     * @since 2.21
+     */
     @Override
     public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint)
             throws JsonMappingException {
@@ -404,7 +404,7 @@ public class RangeMapSerializer
      */
 
     /**
-     * @since 2.15
+     * @since 2.21
      */
     protected <X> RangeMap<Comparable<?>, X> _orderEntriesByKey(RangeMap<Comparable<?>, X> value, JsonGenerator gen, SerializerProvider provider)
             throws IOException {
@@ -414,7 +414,7 @@ public class RangeMapSerializer
             return ordered;
         } catch (ClassCastException e) {
             // Either key or value type not Comparable?
-            // 20-Mar-2023, tatu: Should we actually wrap & propagate failure or... ?
+            // Should we actually wrap & propagate failure or... ?
             return value;
         } catch (NullPointerException e) {
             // Most likely null key that TreeRangeMap won't accept. So... ?

--- a/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/RangeMapSerializer.java
+++ b/guava/src/main/java/com/fasterxml/jackson/datatype/guava/ser/RangeMapSerializer.java
@@ -1,0 +1,444 @@
+package com.fasterxml.jackson.datatype.guava.ser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonArrayFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonMapFormatVisitor;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.ContainerSerializer;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.PropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
+import com.fasterxml.jackson.databind.ser.std.MapProperty;
+import com.fasterxml.jackson.databind.type.MapLikeType;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * Serializer for Guava's {@link RangeMap} values. Output format encloses all
+ * values in JSON Map.
+ */
+public class RangeMapSerializer
+        extends ContainerSerializer<RangeMap<Comparable<?>, ?>>
+        implements ContextualSerializer {
+    private static final long serialVersionUID = 1L;
+
+    private final MapLikeType _type;
+    private final BeanProperty _property;
+    private final JsonSerializer<Object> _keySerializer;
+    private final TypeSerializer _valueTypeSerializer;
+    private final JsonSerializer<Object> _valueSerializer;
+
+    /**
+     * Set of entries to omit during serialization, if any
+     *
+     * @since 2.5
+     */
+    protected final Set<String> _ignoredEntries;
+
+    /**
+     * If value type can not be statically determined, mapping from
+     * runtime value types to serializers are stored in this object.
+     *
+     * @since 2.5
+     */
+    protected PropertySerializerMap _dynamicValueSerializers;
+
+    /**
+     * Id of the property filter to use, if any; null if none.
+     *
+     * @since 2.5
+     */
+    protected final Object _filterId;
+
+    /**
+     * Flag set if output is forced to be sorted by keys (usually due
+     * to annotation).
+     *
+     * @since 2.15
+     */
+    protected final boolean _sortKeys;
+
+    public RangeMapSerializer(MapLikeType type, BeanDescription beanDesc,
+                              JsonSerializer<Object> keySerializer, TypeSerializer vts, JsonSerializer<Object> valueSerializer,
+                              Set<String> ignoredEntries, Object filterId) {
+        super(type.getRawClass(), false);
+        _type = type;
+        _property = null;
+        _keySerializer = keySerializer;
+        _valueTypeSerializer = vts;
+        _valueSerializer = valueSerializer;
+        _ignoredEntries = ignoredEntries;
+        _filterId = filterId;
+        _sortKeys = false;
+
+        _dynamicValueSerializers = PropertySerializerMap.emptyForProperties();
+    }
+
+    /**
+     * @since 2.5
+     */
+    @SuppressWarnings("unchecked")
+    protected RangeMapSerializer(RangeMapSerializer src, BeanProperty property,
+                                 JsonSerializer<?> keySerializer,
+                                 TypeSerializer vts, JsonSerializer<?> valueSerializer,
+                                 Set<String> ignoredEntries, Object filterId, boolean sortKeys) {
+        super(src);
+        _type = src._type;
+        _property = property;
+        _keySerializer = (JsonSerializer<Object>) keySerializer;
+        _valueTypeSerializer = vts;
+        _valueSerializer = (JsonSerializer<Object>) valueSerializer;
+        _dynamicValueSerializers = src._dynamicValueSerializers;
+        _ignoredEntries = ignoredEntries;
+        _filterId = filterId;
+        _sortKeys = sortKeys;
+    }
+
+    protected RangeMapSerializer withResolved(BeanProperty property,
+                                              JsonSerializer<?> keySer, TypeSerializer vts, JsonSerializer<?> valueSer,
+                                              Set<String> ignored, Object filterId, boolean sortKeys) {
+        return new RangeMapSerializer(this, property, keySer, vts, valueSer,
+                ignored, filterId, sortKeys);
+    }
+
+    @Override
+    protected ContainerSerializer<?> _withValueTypeSerializer(TypeSerializer typeSer) {
+        return new RangeMapSerializer(this, _property, _keySerializer,
+                typeSer, _valueSerializer, _ignoredEntries, _filterId, _sortKeys);
+    }
+
+    /*
+    /**********************************************************
+    /* Post-processing (contextualization)
+    /**********************************************************
+     */
+
+    @Override
+    public JsonSerializer<?> createContextual(SerializerProvider provider,
+                                              BeanProperty property) throws JsonMappingException {
+        JsonSerializer<?> valueSer = _valueSerializer;
+        if (valueSer == null) { // if type is final, can actually resolve:
+            JavaType valueType = _type.getContentType();
+            if (valueType.isFinal()) {
+                valueSer = provider.findValueSerializer(valueType, property);
+            }
+        } else if (valueSer instanceof ContextualSerializer) {
+            valueSer = ((ContextualSerializer) valueSer).createContextual(provider, property);
+        }
+
+        final AnnotationIntrospector intr = provider.getAnnotationIntrospector();
+        final AnnotatedMember propertyAcc = (property == null) ? null : property.getMember();
+        JsonSerializer<?> keySer = null;
+        Object filterId = _filterId;
+
+        // First: if we have a property, may have property-annotation overrides
+        if (propertyAcc != null && intr != null) {
+            Object serDef = intr.findKeySerializer(propertyAcc);
+            if (serDef != null) {
+                keySer = provider.serializerInstance(propertyAcc, serDef);
+            }
+            serDef = intr.findContentSerializer(propertyAcc);
+            if (serDef != null) {
+                valueSer = provider.serializerInstance(propertyAcc, serDef);
+            }
+            filterId = intr.findFilterId(propertyAcc);
+        }
+        if (valueSer == null) {
+            valueSer = _valueSerializer;
+        }
+        // [datatype-guava#124]: May have a content converter
+        valueSer = findContextualConvertingSerializer(provider, property, valueSer);
+        if (valueSer == null) {
+            // One more thing -- if explicit content type is annotated,
+            //   we can consider it a static case as well.
+            JavaType valueType = _type.getContentType();
+            if (valueType.useStaticType()) {
+                valueSer = provider.findValueSerializer(valueType, property);
+            }
+        } else {
+            valueSer = provider.handleSecondaryContextualization(valueSer, property);
+        }
+        if (keySer == null) {
+            keySer = _keySerializer;
+        }
+        if (keySer == null) {
+            keySer = provider.findKeySerializer(_type.getKeyType(), property);
+        } else {
+            keySer = provider.handleSecondaryContextualization(keySer, property);
+        }
+        // finally, TypeSerializers may need contextualization as well
+        TypeSerializer typeSer = _valueTypeSerializer;
+        if (typeSer != null) {
+            typeSer = typeSer.forProperty(property);
+        }
+
+        Set<String> ignored = _ignoredEntries;
+        boolean sortKeys = false;
+
+        if (intr != null && propertyAcc != null) {
+            JsonIgnoreProperties.Value ignorals = intr.findPropertyIgnoralByName(provider.getConfig(), propertyAcc);
+            if (ignorals != null) {
+                Set<String> newIgnored = ignorals.findIgnoredForSerialization();
+                if ((newIgnored != null) && !newIgnored.isEmpty()) {
+                    ignored = (ignored == null) ? new HashSet<String>() : new HashSet<>(ignored);
+                    for (String str : newIgnored) {
+                        ignored.add(str);
+                    }
+                }
+            }
+            Boolean b = intr.findSerializationSortAlphabetically(propertyAcc);
+            sortKeys = (b != null) && b.booleanValue();
+        }
+        // 19-May-2016, tatu: Also check per-property format features, even if
+        //    this isn't yet used (as per [guava#7])
+        JsonFormat.Value format = findFormatOverrides(provider, property, handledType());
+        if (format != null) {
+            Boolean B = format.getFeature(JsonFormat.Feature.WRITE_SORTED_MAP_ENTRIES);
+            if (B != null) {
+                sortKeys = B.booleanValue();
+            }
+        }
+        return withResolved(property, keySer, typeSer, valueSer,
+                ignored, filterId, sortKeys);
+    }
+
+    /*
+    /**********************************************************
+    /* Accessors for ContainerSerializer
+    /**********************************************************
+     */
+
+    @Override
+    public JsonSerializer<?> getContentSerializer() {
+        return _valueSerializer;
+    }
+
+    @Override
+    public JavaType getContentType() {
+        return _type.getContentType();
+    }
+
+    @Override
+    public boolean hasSingleElement(RangeMap<Comparable<?>, ?> map) {
+        return map.asMapOfRanges().size() == 1;
+    }
+
+    @Override
+    public boolean isEmpty(SerializerProvider prov, RangeMap<Comparable<?>, ?> value) {
+        return value.asMapOfRanges().isEmpty();
+    }
+
+    /*
+    /**********************************************************
+    /* Post-processing (contextualization)
+    /**********************************************************
+     */
+
+    @Override
+    public void serialize(RangeMap<Comparable<?>, ?> value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        gen.writeStartObject();
+        // [databind#631]: Assign current value, to be accessible by custom serializers
+        gen.assignCurrentValue(value);
+        if (!isEmpty(value)) {
+            if (_sortKeys || provider.isEnabled(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)) {
+                value = _orderEntriesByKey(value, gen, provider);
+            }
+
+            Map<Range<Comparable<?>>, ?> map = value.asMapOfRanges();
+
+            if (_filterId != null) {
+                serializeFilteredFields(map, gen, provider);
+            } else {
+                serializeFields(map, gen, provider);
+            }
+        }
+        gen.writeEndObject();
+    }
+
+    @Override
+    public void serializeWithType(RangeMap<Comparable<?>, ?> value, JsonGenerator gen,
+                                  SerializerProvider provider, TypeSerializer typeSer)
+            throws IOException {
+        gen.assignCurrentValue(value);
+        WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen,
+                typeSer.typeId(value, JsonToken.START_OBJECT));
+        if (!isEmpty(value)) {
+            if (_sortKeys || provider.isEnabled(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)) {
+                value = _orderEntriesByKey(value, gen, provider);
+            }
+
+            Map<Range<Comparable<?>>, ?> map = value.asMapOfRanges();
+
+            if (_filterId != null) {
+                serializeFilteredFields(map, gen, provider);
+            } else {
+                serializeFields(map, gen, provider);
+            }
+        }
+        typeSer.writeTypeSuffix(gen, typeIdDef);
+    }
+
+    private final void serializeFields(Map<Range<Comparable<?>>, ?> rmap, JsonGenerator
+            gen, SerializerProvider provider)
+            throws IOException {
+        final Set<String> ignored = _ignoredEntries;
+        PropertySerializerMap serializers = _dynamicValueSerializers;
+        for (Entry<Range<Comparable<?>>, ?> entry : rmap.entrySet()) {
+            // First, serialize key
+            Range<?> key = entry.getKey();
+            if ((ignored != null) && ignored.contains(key)) {
+                continue;
+            }
+            if (key == null) {
+                provider.findNullKeySerializer(_type.getKeyType(), _property)
+                        .serialize(null, gen, provider);
+            } else {
+                _keySerializer.serialize(key, gen, provider);
+            }
+            Object value = entry.getValue();
+            if (value == null) {
+                provider.defaultSerializeNull(gen);
+                continue;
+            }
+            JsonSerializer<Object> valueSer = _valueSerializer;
+            if (valueSer == null) {
+                Class<?> cc = value.getClass();
+                valueSer = serializers.serializerFor(cc);
+                if (valueSer == null) {
+                    valueSer = _findAndAddDynamic(serializers, cc, provider);
+                    serializers = _dynamicValueSerializers;
+                }
+            }
+            if (_valueTypeSerializer == null) {
+                valueSer.serialize(value, gen, provider);
+            } else {
+                valueSer.serializeWithType(value, gen, provider, _valueTypeSerializer);
+            }
+        }
+    }
+
+    private final void serializeFilteredFields(Map<Range<Comparable<?>>, ?> rmap, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        final Set<String> ignored = _ignoredEntries;
+        PropertyFilter filter = findPropertyFilter(provider, _filterId, rmap);
+        final MapProperty prop = new MapProperty(_valueTypeSerializer, _property);
+        for (Entry<Range<Comparable<?>>, ?> entry : rmap.entrySet()) {
+            // First, serialize key
+            Range<?> key = entry.getKey();
+            if ((ignored != null) && ignored.contains(key)) {
+                continue;
+            }
+            Object value = entry.getValue();
+            JsonSerializer<Object> valueSer;
+            if (value == null) {
+                // !!! TODO: null suppression?
+                valueSer = provider.getDefaultNullValueSerializer();
+            } else {
+                valueSer = _valueSerializer;
+            }
+            prop.reset(key, value, _keySerializer, valueSer);
+            try {
+                filter.serializeAsField(rmap, gen, provider, prop);
+            } catch (Exception e) {
+                String keyDesc = "" + key;
+                wrapAndThrow(provider, e, value, keyDesc);
+            }
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Schema related functionality
+    /**********************************************************
+     */
+
+    @Override
+    public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint)
+            throws JsonMappingException {
+        JsonMapFormatVisitor v2 = (visitor == null) ? null : visitor.expectMapFormat(typeHint);
+        if (v2 != null) {
+            v2.keyFormat(_keySerializer, _type.getKeyType());
+            JsonSerializer<?> valueSer = _valueSerializer;
+            final JavaType vt = _type.getContentType();
+            final SerializerProvider prov = visitor.getProvider();
+            if (valueSer == null) {
+                valueSer = _findAndAddDynamic(_dynamicValueSerializers, vt, prov);
+            }
+            final JsonSerializer<?> valueSer2 = valueSer;
+            v2.valueFormat(new JsonFormatVisitable() {
+                final JavaType arrayType = prov.getTypeFactory().constructArrayType(vt);
+
+                @Override
+                public void acceptJsonFormatVisitor(
+                        JsonFormatVisitorWrapper v3, JavaType hint3)
+                        throws JsonMappingException {
+                    JsonArrayFormatVisitor v4 = v3.expectArrayFormat(arrayType);
+                    if (v4 != null) {
+                        v4.itemsFormat(valueSer2, vt);
+                    }
+                }
+            }, vt);
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Internal helper methods
+    /**********************************************************
+     */
+
+    /**
+     * @since 2.15
+     */
+    protected <X> RangeMap<Comparable<?>, X> _orderEntriesByKey(RangeMap<Comparable<?>, X> value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        try {
+            TreeRangeMap<Comparable<?>, X> ordered = TreeRangeMap.create();
+            ordered.putAll(value);
+            return ordered;
+        } catch (ClassCastException e) {
+            // Either key or value type not Comparable?
+            // 20-Mar-2023, tatu: Should we actually wrap & propagate failure or... ?
+            return value;
+        } catch (NullPointerException e) {
+            // Most likely null key that TreeRangeMap won't accept. So... ?
+            provider.reportMappingProblem("Failed to sort RangeMap entries due to `NullPointerException`: `null` key?");
+            return null;
+        }
+    }
+
+    protected final JsonSerializer<Object> _findAndAddDynamic(PropertySerializerMap map,
+                                                              Class<?> type, SerializerProvider provider) throws JsonMappingException {
+        PropertySerializerMap.SerializerAndMapResult result = map.findAndAddSecondarySerializer(type, provider, _property);
+        // did we get a new map of serializers? If so, start using it
+        if (map != result.map) {
+            _dynamicValueSerializers = result.map;
+        }
+        return result.serializer;
+    }
+
+    protected final JsonSerializer<Object> _findAndAddDynamic(PropertySerializerMap map,
+                                                              JavaType type, SerializerProvider provider) throws JsonMappingException {
+        PropertySerializerMap.SerializerAndMapResult result = map.findAndAddSecondarySerializer(type, provider, _property);
+        if (map != result.map) {
+            _dynamicValueSerializers = result.map;
+        }
+        return result.serializer;
+    }
+}

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/RangeMapsTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/RangeMapsTest.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.google.common.base.Optional;
 import com.google.common.collect.*;
 import org.junit.jupiter.api.Test;
@@ -13,16 +17,14 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests to verify handling of various {@link RangeMap}s.
  *
- * @author steven@nesscomputing.com
+ * @author mcvayc
  */
 public class RangeMapsTest extends ModuleTestBase {
-    // Test for issue #13 on github, provided by stevenschlansker
     public enum MyEnum {
         YAY,
         BOO
@@ -34,13 +36,30 @@ public class RangeMapsTest extends ModuleTestBase {
         RangeMap<String, String> map = TreeRangeMap.create();
     }
 
+    static class RangeMapWithFilter {
+        @JsonProperty
+        @JsonFilter("myFilter")
+        RangeMap<Integer, String> map = TreeRangeMap.create();
+
+        public RangeMapWithFilter() {
+            map.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A");
+            map.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), "B");
+            map.put(Range.range(20, BoundType.OPEN, 30, BoundType.CLOSED), "C");
+            map.put(Range.range(30, BoundType.OPEN, 40, BoundType.CLOSED), "D");
+            map.put(Range.range(40, BoundType.OPEN, 50, BoundType.CLOSED), "E");
+        }
+    }
+
     static class RangeMapWithIgnores {
-        @JsonIgnoreProperties({"x", "y"})
+        @JsonIgnoreProperties({"(20..30]", "(30..40]"})
         public RangeMap<Integer, String> map = TreeRangeMap.create();
 
         public RangeMapWithIgnores() {
             map.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A");
             map.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), "B");
+            map.put(Range.range(20, BoundType.OPEN, 30, BoundType.CLOSED), "C");
+            map.put(Range.range(30, BoundType.OPEN, 40, BoundType.CLOSED), "D");
+            map.put(Range.range(40, BoundType.OPEN, 50, BoundType.CLOSED), "E");
         }
     }
 
@@ -140,7 +159,7 @@ public class RangeMapsTest extends ModuleTestBase {
     }
 
     @Test
-    public void testRangeMapIssue3() throws Exception {
+    public void testRangeMapCompatibilityWithMap() throws Exception {
         RangeMap<Integer, String> m1 = TreeRangeMap.create();
         m1.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A");
         m1.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), "B");
@@ -175,7 +194,7 @@ public class RangeMapsTest extends ModuleTestBase {
     }
 
     @Test
-    public void testEnumValue() throws Exception {
+    public void testRangeMapWithEnumValue() throws Exception {
         final TypeReference<TreeRangeMap<Integer, MyEnum>> type = new TypeReference<TreeRangeMap<Integer, MyEnum>>() {
         };
         final RangeMap<Integer, MyEnum> map = TreeRangeMap.create();
@@ -244,8 +263,26 @@ public class RangeMapsTest extends ModuleTestBase {
 
     @Test
     public void testRangeMapWithIgnores() throws IOException {
-        assertEquals("{\"map\":{\"(0..10]\":\"A\",\"(10..20]\":\"B\"}}",
+        assertEquals("{\"map\":{\"(0..10]\":\"A\",\"(10..20]\":\"B\",\"(40..50]\":\"E\"}}",
                 MAPPER.writeValueAsString(new RangeMapWithIgnores()));
+    }
+
+    @Test
+    public void testRangeMapWithFilters() throws IOException {
+        FilterProvider filters = new SimpleFilterProvider() .addFilter(
+                "myFilter", SimpleBeanPropertyFilter.filterOutAllExcept("(10..20]", "(40..50]"));
+
+        assertEquals("{\"map\":{\"(10..20]\":\"B\",\"(40..50]\":\"E\"}}",
+                MAPPER.writer(filters).writeValueAsString(new RangeMapWithFilter()));
+    }
+
+    @Test
+    public void testRangeMapDeserializationWithEmptyStringKey() throws IOException {
+        ValueInstantiationException exception = assertThrows(ValueInstantiationException.class,() ->
+            MAPPER.readValue("{\"\":\"B\",\"(40..50]\":\"E\"}", new TypeReference<ImmutableRangeMap<String, String>>() {})
+        );
+
+        assertTrue(exception.getMessage().contains("RangeMap keys can't be null or empty."));
     }
 
     @Test
@@ -256,17 +293,6 @@ public class RangeMapsTest extends ModuleTestBase {
 
         ImmutableRangeMapWrapper output = MAPPER.readValue(json, ImmutableRangeMapWrapper.class);
         assertEquals(input, output);
-    }
-
-    @Test
-    public void testFromSingleValue() throws Exception {
-        ObjectMapper mapper = mapperWithModule()
-                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
-        SampleRangeMapTest sampleTest = mapper.readValue("{\"map\":{\"(1..10]\":\"value\"}}",
-                new TypeReference<SampleRangeMapTest>() {
-                });
-
-        assertEquals("value", sampleTest.map.get(5));
     }
 
 }

--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/RangeMapsTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/RangeMapsTest.java
@@ -1,0 +1,272 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.collect.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests to verify handling of various {@link RangeMap}s.
+ *
+ * @author steven@nesscomputing.com
+ */
+public class RangeMapsTest extends ModuleTestBase {
+    // Test for issue #13 on github, provided by stevenschlansker
+    public enum MyEnum {
+        YAY,
+        BOO
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    static class RangeMapWrapper {
+        @JsonProperty
+        RangeMap<String, String> map = TreeRangeMap.create();
+    }
+
+    static class RangeMapWithIgnores {
+        @JsonIgnoreProperties({"x", "y"})
+        public RangeMap<Integer, String> map = TreeRangeMap.create();
+
+        public RangeMapWithIgnores() {
+            map.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A");
+            map.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), "B");
+        }
+    }
+
+    public static class ImmutableRangeMapWrapper {
+
+        private ImmutableRangeMap<Integer, String> rangeMap;
+
+        public ImmutableRangeMapWrapper() {
+        }
+
+        public ImmutableRangeMapWrapper(ImmutableRangeMap<Integer, String> f) {
+            this.rangeMap = f;
+        }
+
+        public ImmutableRangeMap<Integer, String> getRangeMap() {
+            return rangeMap;
+        }
+
+        public void setRangeMap(ImmutableRangeMap<Integer, String> rangeMap) {
+            this.rangeMap = rangeMap;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 97 * hash + (this.rangeMap != null ? this.rangeMap.hashCode() : 0);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final ImmutableRangeMapWrapper other = (ImmutableRangeMapWrapper) obj;
+            return !(this.rangeMap != other.rangeMap && (this.rangeMap == null || !this.rangeMap.equals(other.rangeMap)));
+        }
+    }
+
+    //Sample class for testing rangemaps single value option
+    static class SampleRangeMapTest {
+        public TreeRangeMap<Integer, String> map;
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    private final ObjectMapper MAPPER = mapperWithModule();
+
+    @Test
+    public void testRangeMap() throws Exception {
+        _testRangeMap(TreeRangeMap.create(), true,
+                "{\"(0..10]\":\"A\",\"(10..20]\":\"B\",\"(20..30]\":\"C\",\"(30..40]\":\"D\",\"(40..50]\":\"E\"}");
+        _testRangeMap(TreeRangeMap.create(), false,
+                "{\"(0..10]\":\"A\",\"(10..20]\":\"B\",\"(20..30]\":\"C\",\"(30..40]\":\"D\",\"(40..50]\":\"E\"}");
+        _testRangeMap(TreeRangeMap.create(), false, null);
+    }
+
+    private void _testRangeMap(RangeMap<?, ?> map0, boolean fullyOrdered, String EXPECTED) throws Exception {
+        @SuppressWarnings("unchecked")
+        RangeMap<Integer, String> map = (RangeMap<Integer, String>) map0;
+        map.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A");
+        map.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), "B");
+        map.put(Range.range(20, BoundType.OPEN, 30, BoundType.CLOSED), "C");
+        map.put(Range.range(30, BoundType.OPEN, 40, BoundType.CLOSED), "D");
+        map.put(Range.range(40, BoundType.OPEN, 50, BoundType.CLOSED), "E");
+
+        // Test that typed writes work
+        if (EXPECTED != null) {
+            String json = MAPPER.writerFor(new TypeReference<RangeMap<Integer, String>>() {
+            }).writeValueAsString(map);
+            assertEquals(EXPECTED, json);
+        }
+
+        // And untyped too
+        String serializedForm = MAPPER.writeValueAsString(map);
+
+        if (EXPECTED != null) {
+            assertEquals(EXPECTED, serializedForm);
+        }
+
+        // these seem to be order-sensitive as well, so only use for ordered-maps
+        if (fullyOrdered) {
+            assertEquals(map, MAPPER.readValue(serializedForm, new TypeReference<RangeMap<Integer, String>>() {
+            }));
+            assertEquals(map, MAPPER.readValue(serializedForm, new TypeReference<TreeRangeMap<Integer, String>>() {
+            }));
+            assertEquals(map, MAPPER.readValue(serializedForm, new TypeReference<ImmutableRangeMap<Integer, String>>() {
+            }));
+        }
+    }
+
+    @Test
+    public void testRangeMapIssue3() throws Exception {
+        RangeMap<Integer, String> m1 = TreeRangeMap.create();
+        m1.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A");
+        m1.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), "B");
+        m1.put(Range.range(20, BoundType.OPEN, 30, BoundType.CLOSED), "C");
+
+        ObjectMapper o = MAPPER;
+
+        String t1 = o.writerFor(new TypeReference<TreeRangeMap<String, String>>() {
+        }).writeValueAsString(m1);
+        Map<?, ?> javaMap = o.readValue(t1, Map.class);
+        assertEquals(3, javaMap.size());
+
+        String t2 = o.writerFor(new TypeReference<RangeMap<String, String>>() {
+        }).writeValueAsString(m1);
+        javaMap = o.readValue(t2, Map.class);
+        assertEquals(3, javaMap.size());
+
+        TreeRangeMap<Integer, String> m2 = TreeRangeMap.create();
+        m2.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A");
+        m2.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), "B");
+        m2.put(Range.range(20, BoundType.OPEN, 30, BoundType.CLOSED), "C");
+
+        String t3 = o.writerFor(new TypeReference<TreeRangeMap<String, String>>() {
+        }).writeValueAsString(m2);
+        javaMap = o.readValue(t3, Map.class);
+        assertEquals(3, javaMap.size());
+
+        String t4 = o.writerFor(new TypeReference<RangeMap<String, String>>() {
+        }).writeValueAsString(m2);
+        javaMap = o.readValue(t4, Map.class);
+        assertEquals(3, javaMap.size());
+    }
+
+    @Test
+    public void testEnumValue() throws Exception {
+        final TypeReference<TreeRangeMap<Integer, MyEnum>> type = new TypeReference<TreeRangeMap<Integer, MyEnum>>() {
+        };
+        final RangeMap<Integer, MyEnum> map = TreeRangeMap.create();
+
+        map.put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), MyEnum.BOO);
+        map.put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), MyEnum.YAY);
+
+        final String serializedForm = MAPPER.writerFor(type).writeValueAsString(map);
+
+        assertEquals(serializedForm, MAPPER.writeValueAsString(map));
+        assertEquals(map, MAPPER.readValue(serializedForm, type));
+    }
+
+    @Test
+    public void testEmptyMapExclusion() throws Exception {
+        String json = MAPPER.writeValueAsString(new RangeMapWrapper());
+        assertEquals("{}", json);
+    }
+
+    @Test
+    public void testWithReferenceType() throws Exception {
+        String json = "{\"(0..10]\":5.0,\"(10..20]\":15.0,\"(20..30]\":25.0,\"(30..40]\":35.0,\"(40..50]\":45.0}";
+        TreeRangeMap<Integer, Optional<Double>> result = MAPPER.readValue(
+                json,
+                new TypeReference<TreeRangeMap<Integer, Optional<Double>>>() {
+                });
+
+        assertEquals(5, result.asMapOfRanges().size());
+        assertEquals(
+                ImmutableRangeMap.builder()
+                        .put(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), Optional.of(5.0))
+                        .put(Range.range(10, BoundType.OPEN, 20, BoundType.CLOSED), Optional.of(15.0))
+                        .put(Range.range(20, BoundType.OPEN, 30, BoundType.CLOSED), Optional.of(25.0))
+                        .put(Range.range(30, BoundType.OPEN, 40, BoundType.CLOSED), Optional.of(35.0))
+                        .put(Range.range(40, BoundType.OPEN, 50, BoundType.CLOSED), Optional.of(45.0))
+                        .build(),
+                result);
+    }
+
+    @Test
+    public void testImmutableRangeMap() throws IOException {
+        RangeMap<String, String> map =
+                _verifyRangeMapRead(new TypeReference<ImmutableRangeMap<String, String>>() {
+                });
+        assertTrue(map instanceof ImmutableRangeMap);
+    }
+
+    @Test
+    public void testTreeRangeMap() throws IOException {
+        RangeMap<String, String> map =
+                _verifyRangeMapRead(new TypeReference<TreeRangeMap<String, String>>() {
+                });
+        assertTrue(map instanceof TreeRangeMap);
+    }
+
+    private RangeMap<String, String> _verifyRangeMapRead(TypeReference<?> type)
+            throws IOException {
+        RangeMap<String, String> map = (RangeMap<String, String>) MAPPER
+                .readValue("{\"(a..c]\":\"b\",\"(d..f]\":\"e\",\"(g..i]\":\"h\"}", type);
+        assertEquals(3, map.asMapOfRanges().size());
+        assertTrue(map.asMapOfRanges().containsKey(Range.openClosed("a", "c")));
+        assertTrue(map.asMapOfRanges().containsKey(Range.openClosed("d", "f")));
+        assertTrue(map.asMapOfRanges().containsKey(Range.openClosed("g", "i")));
+        return map;
+    }
+
+    @Test
+    public void testRangeMapWithIgnores() throws IOException {
+        assertEquals("{\"map\":{\"(0..10]\":\"A\",\"(10..20]\":\"B\"}}",
+                MAPPER.writeValueAsString(new RangeMapWithIgnores()));
+    }
+
+    @Test
+    public void testPolymorphicValue() throws IOException {
+        ImmutableRangeMapWrapper input = new ImmutableRangeMapWrapper(ImmutableRangeMap.of(Range.range(0, BoundType.OPEN, 10, BoundType.CLOSED), "A"));
+
+        String json = MAPPER.writeValueAsString(input);
+
+        ImmutableRangeMapWrapper output = MAPPER.readValue(json, ImmutableRangeMapWrapper.class);
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void testFromSingleValue() throws Exception {
+        ObjectMapper mapper = mapperWithModule()
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        SampleRangeMapTest sampleTest = mapper.readValue("{\"map\":{\"(1..10]\":\"value\"}}",
+                new TypeReference<SampleRangeMapTest>() {
+                });
+
+        assertEquals("value", sampleTest.map.get(5));
+    }
+
+}


### PR DESCRIPTION
This commit fixes https://github.com/FasterXML/jackson-datatypes-collections/issues/195 by supporting [Guava RangeMap](https://guava.dev/releases/20.0/api/docs/com/google/common/collect/RangeMap.html) serialization and deserialization for `RangeMaps` that use a `Range` that supports String serialization.  Suggestions and comments welcome.