### PR TITLE
Add special handling for 0 and 1 size Guava immutable collections

### DIFF
--- a/guava/src/main/java/tools/jackson/datatype/guava/deser/GuavaImmutableCollectionDeserializer.java
+++ b/guava/src/main/java/tools/jackson/datatype/guava/deser/GuavaImmutableCollectionDeserializer.java
@@ -47,33 +47,62 @@ abstract class GuavaImmutableCollectionDeserializer<T extends ImmutableCollectio
     protected T _deserializeContents(JsonParser p, DeserializationContext ctxt)
         throws JacksonException
     {
-        ValueDeserializer<?> valueDes = _valueDeserializer;
-        JsonToken t;
-        final TypeDeserializer typeDeser = _valueTypeDeserializer;
-        // No way to pass actual type parameter; but does not matter, just
-        // compiler-time fluff:
-        ImmutableCollection.Builder<Object> builder = createBuilder();
+        Object first = null;
+        int count = 0;
 
-        while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
-            Object value;
-
-            if (t == JsonToken.VALUE_NULL) {
-                if (_skipNullValues) {
-                    continue;
-                }
-                value = _resolveNullToValue(ctxt);
-            } else if (typeDeser == null) {
-                value = valueDes.deserialize(p, ctxt);
-            } else {
-                value = valueDes.deserializeWithType(p, ctxt, typeDeser);
-            }
-
+        while (p.nextToken() != JsonToken.END_ARRAY) {
+            Object value = _deserializeSingleValue(p, ctxt);
             if (value == null) {
-                _tryToAddNull(p, ctxt, builder);
-                continue;
+                // Null values need builder for proper error handling
+                ImmutableCollection.Builder<Object> builder = createBuilder();
+                if (count > 0) {
+                    builder.add(first);
+                }
+                if (!_skipNullValues) {
+                    _tryToAddNull(p, ctxt, builder);
+                }
+                return _finishWithBuilder(p, ctxt, builder);
             }
+            if (count == 0) {
+                first = value;
+                count = 1;
+            } else {
+                ImmutableCollection.Builder<Object> builder = createBuilder();
+                builder.add(first);
+                builder.add(value);
+                return _finishWithBuilder(p, ctxt, builder);
+            }
+        }
 
-            builder.add(value);
+        if (count == 0) {
+            return _createEmpty(ctxt);
+        }
+        return _createWithSingleElement(ctxt, first);
+    }
+
+    private Object _deserializeSingleValue(JsonParser p, DeserializationContext ctxt)
+        throws JacksonException
+    {
+        if (p.currentToken() == JsonToken.VALUE_NULL) {
+            return _resolveNullToValue(ctxt);
+        }
+        return _valueTypeDeserializer == null
+            ? _valueDeserializer.deserialize(p, ctxt)
+            : _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
+    }
+
+    private T _finishWithBuilder(JsonParser p, DeserializationContext ctxt,
+            ImmutableCollection.Builder<Object> builder) throws JacksonException
+    {
+        while (p.nextToken() != JsonToken.END_ARRAY) {
+            Object value = _deserializeSingleValue(p, ctxt);
+            if (value == null) {
+                if (!_skipNullValues) {
+                    _tryToAddNull(p, ctxt, builder);
+                }
+            } else {
+                builder.add(value);
+            }
         }
         // No class outside of the package will be able to subclass us,
         // and we provide the proper builder for the subclasses we implement.

--- a/guava/src/main/java/tools/jackson/datatype/guava/deser/GuavaImmutableCollectionDeserializer.java
+++ b/guava/src/main/java/tools/jackson/datatype/guava/deser/GuavaImmutableCollectionDeserializer.java
@@ -48,14 +48,14 @@ abstract class GuavaImmutableCollectionDeserializer<T extends ImmutableCollectio
         throws JacksonException
     {
         Object first = null;
-        int count = 0;
+        boolean hasFirst = false;
 
         while (p.nextToken() != JsonToken.END_ARRAY) {
             Object value = _deserializeSingleValue(p, ctxt);
             if (value == null) {
                 // Null values need builder for proper error handling
                 ImmutableCollection.Builder<Object> builder = createBuilder();
-                if (count > 0) {
+                if (hasFirst) {
                     builder.add(first);
                 }
                 if (!_skipNullValues) {
@@ -63,9 +63,9 @@ abstract class GuavaImmutableCollectionDeserializer<T extends ImmutableCollectio
                 }
                 return _finishWithBuilder(p, ctxt, builder);
             }
-            if (count == 0) {
+            if (!hasFirst) {
                 first = value;
-                count = 1;
+                hasFirst = true;
             } else {
                 ImmutableCollection.Builder<Object> builder = createBuilder();
                 builder.add(first);
@@ -74,7 +74,7 @@ abstract class GuavaImmutableCollectionDeserializer<T extends ImmutableCollectio
             }
         }
 
-        if (count == 0) {
+        if (!hasFirst) {
             return _createEmpty(ctxt);
         }
         return _createWithSingleElement(ctxt, first);

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -24,4 +24,8 @@ Alexander Nesterenok (@anesterenok)
   `JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY`
  [3.1.0]
 
+Oliver Gillespie (@olivergillespie)
 
+* Contributed #215: (guava) Add special handling for 0 and 1 size Guava
+  immutable collections
+ [3.1.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -10,9 +10,14 @@ Modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+3.1.0 (not yet released)
+
+#215: (guava) Add special handling for 0 and 1 size Guava immutable collections
+ (contributed by Oliver G)
+
 3.1.0-rc1 (26-Jan-2026)
 
-#211: `GuavaMultimapDeserializer` does not respect
+#211: (guava) `GuavaMultimapDeserializer` does not respect
   `JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY`
  (reported by Alexander N)
 


### PR DESCRIPTION
We do not need to create a Builder for the cases of 0 or 1 elements in a collection, and avoiding it reduces allocation and init work. I saw this in an allocation profile from an application I have which processes a lot of 1-element collections. I appreciate that this is somewhat specialized, but I don't think it hurts the code much when it doesn't apply and provides a nice benefit when it does.

Results from a simple [benchmark](https://gist.github.com/olivergillespie/76894e1c669ad5ac70a0c7b0f9a2d732) with Corretto 25.0.1 on Linux x86:

#### Execution time (ns/op)

| Benchmark | Baseline | Improved | Change |
|-----------|----------|----------|--------|
| empty | 28 ± 1.5 | 27 ± 0.84 | within error  |
| oneElement | 59 ± 13 | 50 ± 1.6 | -15% |
| twoElements | 85 ± 1.5 | 73 ± 0.52 | -14% |
| thousandElements | 26000 ± 2000 | 27000 ± 5100 | within error |

#### Allocations (bytes/op)

| Benchmark | Baseline | Improved | Change |
|-----------|----------|----------|--------|
| empty | 16 | 16 | 0 |
| oneElement | 64 | 32 | -50% |
| twoElements | 88 | 56 | -36% |
| thousandElements | 18000 | 18000 | 0 |

Nice reduction as expected for one element and no regression I can see for the general case. Surprisingly also a similar benefit for two elements, this turns out to be from Hotspot eliding the Builder creation all by itself. That does suggest there might a different approach, just restructuring to be more amenable to escape analysis in general without explicitly special-casing, but that's more fragile and I don't think this is too ugly.

Passes existing tests.